### PR TITLE
Adding RTC_S1_STATIC capability

### DIFF
--- a/docs/workflows/aws.md
+++ b/docs/workflows/aws.md
@@ -1,24 +1,54 @@
 # AWS Pipeline
 
-## Overview
+## About 
+
+The AWS sar-pipeline can be used to create two products using the OPERA ISCE3 based workflows. These are:
+- **RTC_S1** -> Sentinel-1 Radiometrically Terrain Corrected (RTC) Backscatter [(Specification doc)](https://d2pn8kiwq2w21t.cloudfront.net/documents/ProductSpec_RTC-S1-STATIC.pdf)
+- **RTC_S1_STATIC** -> Sentinel-1 Radiometrically Terrain Corrected (RTC) Backscatter [(Specification doc)](https://d2pn8kiwq2w21t.cloudfront.net/documents/ProductSpec_RTC-S1.pdf)
+
+**RTC_S1** products are unique to each acquisition. **RTC_S1_STATIC** products are ancillary layers that can be shared across the same burst_id.
+
+
+The **RTC_S1** pipeline must be run for every new scene acquired by Sentinel-1. The **RTC_S1_STATIC** product only needs to be run a single time to create static layers that are fixed for each burst. These layers will need to be recreated only if the acquisition scenario or DEM changes. OR if the area of interest for the DE-Australia and DE-Antarctica project changes. Examples of static layers include `local_incidence_angles` and `digital_elevation_models`. Given the highly stable orbital tube of sentinel-1, these layers can be considered STATIC for a given burst.
+
+The static layers can be re-used across a given burst_id, saving the storage required if they were created with each acquisition. For example, every 12 days sentinel 1A will capture the burst `t070_149815_iw3`. The same `local_incidence_angles.tif` can be used for each repeat pass, only the dialectic properties of the surface will change over time. The static layer is therefore referenced in a given **RTC_S1** product STAC metadata.
+
+TODO: Ensure this is how products are structured 
+
+After each run is completed, the files will be uploaded to a specified S3 bucket location. A unique subpath for each product is created in the workflow.
+
+## Examples
+
+Example outputs of the **RTC_S1** and **RTC_S1_STATIC** workflows can be found here:
+- **RTC_S1** -> https://deant-data-public-dev.s3.ap-southeast-2.amazonaws.com/index.html?prefix=experimental/s1_rtc_c1/2022/1/1/t070_149815_iw3/
+- **RTC_S1_STATIC** -> https://deant-data-public-dev.s3.ap-southeast-2.amazonaws.com/index.html?prefix=experimental/s1_rtc_static_c1/t070_149815_iw3/ 
+
+
+## Pipeline Overview
 The AWS pipeline runs using a docker container. At runtime, the script `scripts/run_aws_pipeline.sh` is run. The arguments that can be passed to the container are:
 
 ```bash
 --scene="" (required)
+--burst_id_list=()
 --resolution=20
 --output_crs=""
 --dem="cop_glo30"
+--product="RTC_S1"
 --collection="s1_rtc_c1"
 --s3_bucket="deant-data-public-dev"
---s3_project_folder="experimental/s1_rtc_c1"
+--s3_project_folder="experimental"
 ```
 - `scene` -> A valid sentinel-1 IW scene (e.g. S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD)
+- `burst_id_list` -> A list of burst id's corresponding to the scene. If not provided, all will be processed. Can be space separated list or line separated .txt file.
 - `resolution` -> The target resolution of the products. Default is 20m.
 - `output_crs` -> The target crs of the products. If not specified, the UTM of the scene center will be used. Expects integer values (e.g. 3031)
 - `dem` -> The dem to be used in processing. Supported is `cop_glo30`.
+- `product` -> The product being created with the workflow. Must be `RTC_S1` or `RTC_S1_STATIC`.
 - `collection` -> The collection which the set of products belongs.
 - `s3_bucket` -> the bucket to upload the products
-- `s3_project_folder` -> The project folder to upload to. Note a unique subpath is appended to this in the pipeline
+- `s3_project_folder` -> The project folder to upload to. Final 
+    - **RTC_S1** -> final path will be `s3_bucket/s3_project_folder/collection/burst_year/burst_month/burst_day/burst_id/*files*`
+    - **RTC_S1_STATIC** -> final path will be `s3_bucket/s3_project_folder/collection/burst_id/*files*`
 
 ## Envrionment Variables
 
@@ -58,7 +88,9 @@ docker build -t sar-pipeline -f Docker/Dockerfile .
  docker run -it --entrypoint /bin/bash sar-pipeline
 ```
 
-## Run a scene
+# Runing the workflow
+
+## RTC_S1 - Sentinel-1 Radiometrically Terrain Corrected (RTC) Backscatter
 
 ### Antarctica
 
@@ -68,20 +100,33 @@ Output CRS should be polar stereographic 3031
 docker run --env-file env.secret -it sar-pipeline --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031
 ```
 
+For a single burst:
+
+```bash
+docker run --env-file env.secret -it sar-pipeline --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031 --burst_id_list t070_149815_iw3
+```
+
 ### Australia
 
-Output CRS should be the UTM zone corresponding to scene/burst center. 
+Output CRS should be the UTM zone corresponding to scene/burst center, and is not specified. 
 
 ```bash
 docker run --env-file env.secret -it sar-pipeline --scene S1A_IW_SLC__1SDV_20220130T191354_20220130T191421_041694_04F5F9_1AFD 
 ```
 
-## Development in the Container
+## RTC_S1_STATIC - Static Layers for Sentinel-1 Radiometrically Terrain Corrected (RTC) Backscatter
 
-Development within container
 
 ```bash
+docker run --env-file env.secret -it sar-pipeline --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031 --product RTC_S1_STATIC --collection s1_rtc_static_c1 --s3_project_folder "experimental"
+```
 
+
+## Development in the Container
+
+Development is best done from within the container where edited files are tracked and can be run without a new installation. To do this, the sar-pipeline project and run scripts must be mounted at the appropriate location within the container.
+
+```bash
 # Start the container interactively and mount folders in the container so changes can be picked up
 # Here the /data/working volume is being mounted to the working directory of the container
 
@@ -97,19 +142,29 @@ pip install -e /home/rtc_user/sar-pipeline
 
 chmod +x /home/rtc_user/scripts/run_aws_pipeline.sh 
 
-# Antarctic scene
+# Antarctic scene (all bursts)
 
 /home/rtc_user/scripts/run_aws_pipeline.sh --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031
+
+# Antarctic scene (single burst)
+
+/home/rtc_user/scripts/run_aws_pipeline.sh --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031 --burst_id_list t070_149815_iw3
 
 # Australia scene
 
 /home/rtc_user/scripts/run_aws_pipeline.sh --scene S1A_IW_SLC__1SDV_20220130T191354_20220130T191421_041694_04F5F9_1AFD
 
+# Antarctica static layers
+
+/home/rtc_user/scripts/run_aws_pipeline.sh --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031 --product RTC_S1_STATIC --collection s1_rtc_static_c1 --s3_project_folder "experimental"
+
+
 ```
 
-Mount files at runtime
+### Mount files at runtime
 
 ```bash
 docker run --env-file env.secret -v $(pwd)/scripts:/home/rtc_user/scripts -v /data/working:/home/rtc_user/working sar-pipeline --scene S1A_IW_SLC__1SSH_20220101T124744_20220101T124814_041267_04E7A2_1DAD --output_crs 3031
 
 ```
+

--- a/docs/workflows/aws.md
+++ b/docs/workflows/aws.md
@@ -108,7 +108,7 @@ docker run --env-file env.secret -it sar-pipeline --scene S1A_IW_SLC__1SSH_20220
 
 ### Australia
 
-Output CRS should be the UTM zone corresponding to scene/burst center, and is not specified. 
+The output CRS will be the UTM zone corresponding to scene/burst centre. This is selected automatically and does not need to be specified.
 
 ```bash
 docker run --env-file env.secret -it sar-pipeline --scene S1A_IW_SLC__1SDV_20220130T191354_20220130T191421_041694_04F5F9_1AFD 

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
     "--burst_id_list",
     required=False,
     multiple=True, 
-    help="List of burst IDs separated by space. e.g. t070_149815_iw3",
+    help="List of burst IDs separated by space. e.g. t070_149815_iw2 t070_149815_iw3",
 )
 @click.option(
     "--resolution",

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -238,9 +238,8 @@ def make_rtc_opera_stac_and_upload_bursts(
         shutil.copy(run_config_path, burst_folder / run_config_path.name)
         # load in the .h5 file containing metadata for each burst
         burst_h5_files = list(burst_folder.glob("*.h5"))
-        assert (
-            len(burst_h5_files) == 1
-        ), f"{len(burst_h5_files)} .h5 files found. Expecting 1 in : {burst_folder}"
+        if len(burst_h5_files) != 1:
+            raise ValueError(f"{len(burst_h5_files)} .h5 files found. Expecting 1 in : {burst_folder}")
         burst_h5_filepath = burst_folder / burst_h5_files[0]
         # make the stac metadata from the .h5 metadata
         logging.info(f"Making stac metadata from .h5 file")

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -12,27 +12,39 @@ from dateutil.parser import isoparse
 import numpy as np
 
 from sar_pipeline.aws.metadata.h5 import H5Manager
-from sar_pipeline.utils.spatial import polygon_str_to_geojson
+from sar_pipeline.utils.spatial import polygon_str_to_geojson, convert_bbox
 
 import logging
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-REQUIRED_ASSET_FILETYPES = [
-    "_mask.tif",
-    "_number_of_looks.tif",
-    "_rtc_anf_gamma0_to_beta0.tif",
-    "_rtc_anf_gamma0_to_sigma0.tif",
-    "_HH.tif",
-    "_HV.tif",
-    "_VV.tif",
-    "_VH.tif",
-    "_local_incidence_angle.tif",
-    "_incidence_angle.tif",
-    "_interpolated_dem.tif",
-    ".png",
-]
+REQUIRED_ASSET_FILETYPES = {
+    "RTC_S1" : [
+        "_mask.tif",
+        "_number_of_looks.tif",
+        "_rtc_anf_gamma0_to_beta0.tif",
+        "_rtc_anf_gamma0_to_sigma0.tif",
+        "_HH.tif",
+        "_HV.tif",
+        "_VV.tif",
+        "_VH.tif",
+        "_local_incidence_angle.tif",
+        "_incidence_angle.tif",
+        "_interpolated_dem.tif",
+        ".png",
+    ],
+    "RTC_S1_STATIC" : [
+        "_mask.tif",
+        "_number_of_looks.tif",
+        "_rtc_anf_gamma0_to_beta0.tif",
+        "_rtc_anf_gamma0_to_sigma0.tif",
+        "_local_incidence_angle.tif",
+        "_incidence_angle.tif",
+        "_interpolated_dem.tif",
+        ".png",
+    ]
+}
 
 ASSET_FILETYPE_TO_TITLE = {
     "_mask.tif": "mask",
@@ -101,6 +113,7 @@ class BurstH5toStacManager:
     def __init__(
         self,
         h5_filepath: Path,
+        product: str,
         collection: str,
         s3_bucket: str,
         s3_project_folder: str,
@@ -111,6 +124,8 @@ class BurstH5toStacManager:
         ----------
         h5_filepath : Path
             Local path to the .h5 file output from the opera/RTC process
+        product: str
+            The product being made. RTC_S1 or RTC_S1_STATIC
         collection : str
             The collection the product belongs to. e.g. s1_rtc_c1
         s3_bucket : str
@@ -124,6 +139,7 @@ class BurstH5toStacManager:
         self.h5_filepath = h5_filepath
         self.h5 = H5Manager(self.h5_filepath)  # class to help get values from .h5 file
         self.id = self.h5_filepath.stem
+        self.product = self._check_valid_product(product)
         self.collection = collection
         self.stac_extensions = [
             "https://stac-extensions.github.io/product/v0.1.0/schema.json",
@@ -144,16 +160,44 @@ class BurstH5toStacManager:
         self.end_dt = isoparse(
             self.h5.search_value("identification/zeroDopplerEndTime")
         )
-        self.geometry_4326 = polygon_str_to_geojson(
-            self.h5.search_value("boundingPolygon")
-        )
-        self.bbox_4326 = shape(self.geometry_4326["geometry"]).bounds
+        self.projection = self.h5.search_value("data/projection")
+        if self.product == "RTC_S1":
+            self.geometry_4326 = polygon_str_to_geojson(
+                self.h5.search_value("boundingPolygon")
+            )
+            self.bbox_4326 = shape(self.geometry_4326["geometry"]).bounds
+        elif self.product == "RTC_S1_STATIC":
+            # 4326 needs to be converted from native coordinates
+            self.bbox_4326 = convert_bbox(
+                self.h5.search_value("boundingBox"),
+                src_crs=self.projection,
+                trg_crs=4326
+            )
+            # geometry is not included, set this to be bbox
+            self.geometry_4326 = self.bbox_4326
+
         self.burst_id = self.h5.search_value("burstID")
-        self.burst_s3_subfolder = f"{self.s3_project_folder}/{self.collection}/{self.start_dt.year}/{self.start_dt.month}/{self.start_dt.day}/{self.burst_id}"
+        self.burst_s3_subfolder = self._make_s3_subfolder()
         self.bucket_href = (
             f"https://{self.s3_bucket}.s3.{self.s3_region}.amazonaws.com//"
         )
         self.base_href = Path(self.bucket_href) / self.burst_s3_subfolder
+
+    def _check_valid_product(self, product):
+        "check the product is valid"
+        assert product in ["RTC_S1", "RTC_S1_STATIC"], "Invalid product"
+        return product
+
+    def _make_s3_subfolder(self):
+        "make the s3 subfolder destination based on the product"
+        if self.product == "RTC_S1":
+            # include acquisition dates for S1_RTC
+            return f"{self.s3_project_folder}/{self.collection}/{self.start_dt.year}/{self.start_dt.month}/{self.start_dt.day}/{self.burst_id}"
+        if self.product == "RTC_S1_STATIC":
+            # static products are date independent
+            return f"{self.s3_project_folder}/{self.collection}/{self.burst_id}"
+        else:
+            raise ValueError()
 
     def make_stac_item_from_h5(self):
         """Make a pystac.item.Item for the given burst using key properties
@@ -190,7 +234,7 @@ class BurstH5toStacManager:
         self.item.properties["product:timeliness"] = ""  # NRT etc see docs
 
         # add projection (proj) stac extension properties
-        self.item.properties["proj:epsg"] = self.h5.search_value("data/projection")
+        self.item.properties["proj:epsg"] = self.projection
         self.item.properties["proj:bbox"] = self.h5.search_value("boundingBox")
 
         # add sat stac extension properties
@@ -357,13 +401,17 @@ class BurstH5toStacManager:
 
         # remove polarizations we don't have from the required products
         # e.g. don't try add HH if it did not exist in original source data
+        if self.product == 'RTC_S1':
+            pols = self.item.properties["sar:polarizations"]
+        elif self.product == 'RTC_S1_STATIC':
+            pols = [] # no pol for static products
         IGNORE_ASSETS = [
             f"_{p}.tif"
             for p in ["HH", "HV", "VV", "VH"]
-            if p not in self.item.properties["sar:polarizations"]
+            if p not in pols
         ]
         INCLUDED_ASSET_FILETYPES = [
-            x for x in REQUIRED_ASSET_FILETYPES if x not in IGNORE_ASSETS
+            x for x in REQUIRED_ASSET_FILETYPES[self.product] if x not in IGNORE_ASSETS
         ]
 
         # iterate through the included/required assets and add to STAC item

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -185,7 +185,8 @@ class BurstH5toStacManager:
 
     def _check_valid_product(self, product):
         "check the product is valid"
-        assert product in ["RTC_S1", "RTC_S1_STATIC"], "Invalid product"
+        if product not in ["RTC_S1", "RTC_S1_STATIC"]:
+            raise ValueError("Invalid product")
         return product
 
     def _make_s3_subfolder(self):

--- a/sar_pipeline/aws/preparation/config.py
+++ b/sar_pipeline/aws/preparation/config.py
@@ -23,9 +23,8 @@ class RTCConfigManager:
         self.data = self._load_yaml()
 
     def _validate(self, base_config, config_path):
-        assert (
-            base_config is not None or config_path is not None
-        ), "A `base_config` or `config_path` must be provided"
+        if base_config is None and config_path is None:
+            raise ValueError("A `base_config` or `config_path` must be provided")
         if base_config is not None and config_path is not None:
             logger.info(
                 "Both `base_config` or `config_path` provided. "
@@ -34,9 +33,8 @@ class RTCConfigManager:
 
     def _get_base_config_path(self):
         # get the path to the specified base config
-        assert (
-            self.base_config in VALID_BASE_CONFIGS
-        ), "specified base rtc_config is not valid"
+        if self.base_config not in VALID_BASE_CONFIGS:
+            raise ValueError("specified base rtc_config is not valid")
         return BASE_CONFIGS_FOLDER / self.base_config
 
     def _load_yaml(self):

--- a/sar_pipeline/aws/preparation/config.py
+++ b/sar_pipeline/aws/preparation/config.py
@@ -6,7 +6,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-VALID_BASE_CONFIGS = ["S1_RTC.yaml"]
+VALID_BASE_CONFIGS = ["S1_RTC.yaml","S1_RTC_STATIC.yaml"]
 BASE_CONFIGS_FOLDER = Path(__file__).parents[2] / "configs/ISCE3-RTC"
 
 

--- a/sar_pipeline/configs/ISCE3-RTC/S1_RTC_STATIC.yaml
+++ b/sar_pipeline/configs/ISCE3-RTC/S1_RTC_STATIC.yaml
@@ -1,0 +1,329 @@
+runconfig:
+    name: rtc_s1_workflow_default
+
+    groups:
+
+        primary_executable:
+
+        # Required. Output product type: "RTC_S1" or "RTC_S1_STATIC"
+            product_type: RTC_S1_STATIC
+
+        pge_name_group:
+            pge_name: RTC_S1_PGE
+
+        input_file_group:
+            # Required. List of SAFE files (min=1)
+            safe_file_path:
+
+            # Location from where the source data can be retrieved (URL or DOI)
+            source_data_access:
+
+            # Required. List of orbit (EOF) files (min=1)
+            orbit_file_path:
+
+            # Optional. Burst ID to process (empty for all bursts)
+            burst_id:
+
+        dynamic_ancillary_file_group:
+            # Digital elevation model
+            dem_file:
+
+            # Digital elevation model source description
+            dem_file_description:
+
+        static_ancillary_file_group:
+
+            # burst database sqlite file
+            burst_database_file: /home/rtc_user/burst_db/opera-burst-bbox-only.sqlite3
+
+        product_group:
+
+            processing_type: NOMINAL
+
+            product_version:
+
+            # Directory where PGE will place results
+            product_path: .
+            # Directory where SAS writes temporary data
+            scratch_path:
+
+            # If option `save_bursts` is set, output bursts are saved to:
+            #     {output_dir}/{burst_id}/{product_id}{suffix}.{ext}
+            # If option `save_mosaics` is set, output mosaics are saved to:
+            #     {output_dir}/{product_id}{suffix}.{ext}
+            #
+            # If the `product_id` contains the substring "_{burst_id}", the
+            # substring will be substituted by either:
+            #     - "_" followed by the burst ID, if the product is a burst; or
+            #     - An empty string, if the product is a mosaic.
+            #
+            # For example, the `product_id` = `RTC-S1-STATIC_{burst_id}_S1B` will become
+            # `RTC-S1-STATIC_069-147170-IW1_S1B` for the burst t069-147170-IW1; and it
+            # will become `RTC-S1-STATIC_S1B` for the mosaic product.
+            #
+            # If the field `product_id` is left empty, the burst product ID will
+            # follow the RTC-S1-STATIC file naming conventions:
+            # `OPERA_L2_RTC-S1-STATIC_{burst_id}_{rtc_s1_static_validity_start_date}_
+            # {processing_datetime}_{sensor}_{pixel_spacing}
+            #  _{product_version}`.
+            #
+            # `suffix` is only used when there are multiple output files.
+            # `ext` is determined by geocoding_options.output_imagery_format.
+            output_dir:
+            product_id:
+
+            # Validity start date for RTC-S1-STATIC products in the format YYYYMMDD
+            rtc_s1_static_validity_start_date:
+
+            # Location from where the output product can be retrieved (URL or DOI)
+            product_data_access:
+
+            # Location of the static layers product associated with this product (URL or DOI
+            static_layers_data_access:
+
+            # Save RTC-S1 bursts
+            save_bursts: True
+
+            # Save mosaic of RTC-S1 bursts
+            save_mosaics: False
+
+            # Save browse image(s)
+            save_browse: True
+
+            output_imagery_format: COG
+            output_imagery_compression: DEFLATE
+            output_imagery_nbits: 32
+
+            # Optional. Save secondary layers (e.g., inc. angle) within 
+            # the HDF5 file
+            save_secondary_layers_as_hdf5: False
+
+            # Save RTC-S1 metadata in the HDF5 format
+            # Optional for `output_imagery_format` equal to 'ENVI', 'GTiff', or
+            # 'COG', and enabled by default for `output_imagery_format` equal
+            # to 'HDF5' or 'NETCDF' or `save_secondary_layers_as_hdf5` is True
+            save_metadata: True
+
+        processing:
+
+            # Check if ancillary inputs cover entirely the output product
+            check_ancillary_inputs_coverage: True
+
+            # Polarization channels to process. 
+            polarization:
+
+            # Options to run geo2rdr
+            geo2rdr:
+                threshold: 1.0e-7
+                numiter: 50
+
+            # Options to run rdr2geo
+            rdr2geo:
+                threshold: 1.0e-7
+                numiter: 25
+
+            # DEM interpolation method
+            dem_interpolation_method: biquintic
+
+            # Apply absolute radiometric correction
+            apply_absolute_radiometric_correction: True
+ 
+            # Apply thermal noise correction
+            apply_thermal_noise_correction: True
+
+            # slant range spacing of the correction LUT in meters
+            correction_lut_range_spacing_in_meters: 120
+            # Azimuth time spacing of the correction LUT in meters
+            correction_lut_azimuth_spacing_in_meters: 120
+
+            # OPTIONAL - Apply RTC
+            apply_rtc: True
+
+            # Apply bistatic delay correction
+            apply_bistatic_delay_correction: False
+
+            # Apply static tropospheric delay correction
+            apply_static_tropospheric_delay_correction: False
+ 
+            # OPTIONAL - to control behavior of RTC module
+            # (only applicable if geocode.apply_rtc is True)
+            rtc:
+                # OPTIONAL - Choices:
+                # "gamma0" (default)
+                # "sigma0"
+                output_type: gamma0
+
+                # OPTIONAL - Choices:
+                # "bilinear_distribution" (default)
+                # "area_projection"
+                algorithm_type: area_projection
+
+                # OPTIONAL - Choices:
+                # "beta0" (default)
+                # "sigma0"
+                input_terrain_radiometry: beta0
+
+                # OPTIONAL - Minimum RTC area factor in dB
+                rtc_min_value_db: -30
+
+                # RTC DEM upsampling
+                dem_upsampling: 2
+
+                # RTC area beta mode
+                area_beta_mode: auto
+
+            # OPTIONAL - to provide the number of processes when processing the bursts in parallel
+            # "0" means that the number will be automatically decided based on
+            # the number of cores, `OMP_NUM_THREADS` in environment setting,
+            # and the number of burst to process in runconfig
+            num_workers: 0
+
+            # Geocoding options
+            geocoding:
+
+                # Apply valid-samples sub-swath masking
+                apply_valid_samples_sub_swath_masking: True
+
+                # Apply shadow masking
+                apply_shadow_masking: True
+  
+                # Skip geocoding already processed, which is tested by the existence of the output files
+                skip_if_output_files_exist: False
+
+                # Geocoding algorithm type. Choices "area_projection"
+                # for adaptive multilooking or an interpolation algorithm:
+                # "sinc", "bilinear", "bicubic", "nearest", and "biquintic"
+                algorithm_type: area_projection
+    
+                # OPTIONAL - Choices: "single_block", "geogrid", "geogrid_and_radargrid", and "auto" (default)
+                memory_mode:
+
+                # OPTIONAL - Processing upsampling factor applied to input geogrid
+                geogrid_upsampling: 1
+
+                # Save the incidence angle
+                save_incidence_angle: True
+
+                # Save the local-incidence angle
+                save_local_inc_angle: True
+
+                # Save the projection angle
+                save_projection_angle: False
+
+                # Save the RTC area normalization factor (ANF) computed with
+                # the projection angle method
+                save_rtc_anf_projection_angle: False
+
+                # Save the range slope angle
+                save_range_slope: False
+
+                # Save the number of looks used to generate the RTC-S1 product
+                save_nlooks: True
+              
+                # Save the area normalization factor (ANF) to normalize RTC-S1
+                # imagery to the original SLC backscatter convention:
+                # beta0 or sigma0 (ellipsoid)
+                save_rtc_anf: True
+
+                # Save the RTC area normalization factor (ANF) gamma0 to sigma0
+                save_rtc_anf_gamma0_to_sigma0: True
+
+                # Save the interpolated DEM used to generate the RTC-S1 product
+                save_dem: True
+
+                # Save layover shadow mask
+                save_mask: True
+
+                # Layover/shadow mask dilation size of shadow pixels
+                # (values 1 and 3)
+                shadow_dilation_size: 0
+
+                # OPTIONAL - Absolute radiometric correction
+                abs_rad_cal: 1
+
+                # OPTIONAL - Clip values above threshold
+                clip_max:
+
+                # OPTIONAL - Clip values below threshold
+                clip_min:
+
+                # Double SLC sampling in the range direction
+                upsample_radargrid: False
+
+                # Fields to populate the products' metadata required by
+                # CEOS Analysis Ready Data specifications
+                estimated_geometric_accuracy_bias_x:
+                estimated_geometric_accuracy_bias_y:
+                estimated_geometric_accuracy_stddev_x:
+                estimated_geometric_accuracy_stddev_y:
+
+                bursts_geogrid:
+
+                    # Bursts' EPSG code. If not provided, `output_epsg` will
+                    # be determined based on the scene center:
+                    # - If center_lat >= 75.0: 3413
+                    # - If center_lat <= -75.0: 3031
+                    # - Otherwise: EPSG code associated with the closest UTM zone
+                    output_epsg:
+                    x_posting: 
+                    y_posting: 
+                    x_snap: 
+                    y_snap: 
+                    top_left:
+                        x:
+                        y:
+                    bottom_right:
+                        x:
+                        y:
+
+            # Mosaicking options
+            mosaicking:
+
+                # OPTIONAL - Choices: "average", "first", "bursts_center" (default)
+                mosaic_mode: first
+
+                mosaic_geogrid:
+
+                    # Mosaic EPSG code. If not provided, `output_epsg` will
+                    # be determined based on the scene center:
+                    # - If center_lat >= 75.0: 3413
+                    # - If center_lat <= -75.0: 3031
+                    # - Otherwise: EPSG code associated with the closest UTM zone
+                    output_epsg:
+                    x_posting: 
+                    y_posting: 
+                    x_snap: 
+                    y_snap: 
+                    top_left:
+                        x:
+                        y:
+                    bottom_right:
+                        x:
+                        y:
+
+
+            browse_image_group:
+
+                # If neither height or width parameters are provided, the browse
+                # image is generated with the same pixel spacing of the RTC-S1 
+                # imagery (burst or mosaic).
+
+                # If the height parameter is provided but the width is not provided,
+                # a new width is assigned in order to keep the aspect ratio
+                # of the RTC-S1 geographic grid.
+
+                # Conversely, if the width parameter is provided but the height is not,
+                # a new height is assigned in order to keep the aspect ratio
+                # of the RTC-S1 geographic grid.
+
+                # Height in pixels for the PNG browse image of RTC-S1 bursts.
+                browse_image_burst_height: 2048
+
+                # Width in pixels for the PNG browse image of RTC-S1 bursts
+                browse_image_burst_width:
+
+                # Height in pixels for the PNG browse image of RTC-S1 mosaics.
+                browse_image_mosaic_height: 2048
+
+                # Width in pixels for the PNG browse image of RTC-S1 mosaics
+                browse_image_mosaic_width:

--- a/sar_pipeline/utils/spatial.py
+++ b/sar_pipeline/utils/spatial.py
@@ -1,3 +1,5 @@
+from pyproj import Transformer
+
 def polygon_str_to_geojson(polygon_str: str) -> dict:
     """convert polygon string to a geojson
 
@@ -18,3 +20,31 @@ def polygon_str_to_geojson(polygon_str: str) -> dict:
         "geometry": {"type": "Polygon", "coordinates": [coordinates]},
     }
     return geojson
+
+def convert_bbox(bbox, src_crs, trg_crs):
+    """
+    Convert a bounding box from one CRS to another.
+    
+    Parameters:
+        bbox (tuple): Bounding box as (min_x, min_y, max_x, max_y).
+        src_crs (str or int): Source coordinate reference system (EPSG code or proj string).
+        trg_crs (str or int): Target coordinate reference system (EPSG code or proj string).
+    
+    Returns:
+        tuple: Transformed bounding box (min_x, min_y, max_x, max_y).
+    """
+    transformer = Transformer.from_crs(src_crs, trg_crs, always_xy=True)
+    
+    # Transform all four corners
+    x1, y1 = transformer.transform(bbox[0], bbox[1])
+    x2, y2 = transformer.transform(bbox[2], bbox[1])
+    x3, y3 = transformer.transform(bbox[2], bbox[3])
+    x4, y4 = transformer.transform(bbox[0], bbox[3])
+    
+    # Compute new bounding box
+    min_x = min(x1, x2, x3, x4)
+    max_x = max(x1, x2, x3, x4)
+    min_y = min(y1, y2, y3, y4)
+    max_y = max(y1, y2, y3, y4)
+    
+    return min_x, min_y, max_x, max_y

--- a/scripts/run_aws_pipeline.sh
+++ b/scripts/run_aws_pipeline.sh
@@ -2,10 +2,12 @@
 
 # Default values for the container
 scene=""
+burst_ids=() # list of burst_ids or line separated .txt file
 resolution=20
 output_crs=""
 dem="cop_glo30"
-collection="s1_rtc_c1"
+product="RTC_S1" # RTC_S1_STATIC or RTC_S1
+collection="s1_rtc_c1" # e.g. s1_rtc_c1 or s1_rtc_static_c1
 s3_bucket="deant-data-public-dev"
 s3_project_folder="experimental"
 
@@ -16,9 +18,24 @@ while [[ "$#" -gt 0 ]]; do
         --resolution) resolution="$2"; shift ;; 
         --output_crs) output_crs="$2"; shift ;; 
         --dem) dem="$2"; shift ;;
+        --product) product="$2"; shift ;;
         --collection) collection="$2"; shift ;;
         --s3_bucket) s3_bucket="$2"; shift ;;
         --s3_project_folder) s3_project_folder="$2"; shift ;;
+        --burst_id_list)
+            shift  # Move past the flag
+            if [[ $# -eq 1 && -f "$1" ]]; then
+                # If only one argument remains and it's a file, read burst IDs from it
+                burst_ids=($(cat "$1"))
+                shift
+            else
+                # Otherwise, treat remaining arguments as burst IDs
+                while [[ $# -gt 0 && ! "$1" =~ ^-- ]]; do
+                    burst_ids+=("$1")
+                    shift
+                done
+            fi
+            ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
@@ -42,23 +59,32 @@ fi
 # OR, the CRS from the burst_db is used if provided.
 
 if [[ -z "$output_crs" ]]; then
-    epsg_code="default UTM for scene center"
+    epsg_code_msg="default UTM for scene center"
 else
     # Check if the parameter is an integer using regex
     if ! [[ "$output_crs" =~ ^[0-9]+$ ]]; then
         echo "Error: --output_crs must be an integer corresponding to a CRS code (e.g. 3031) or empty."
         exit 1
     else
-        epsg_code="EPSG:$output_crs"
+        epsg_code_msg="EPSG:$output_crs"
     fi
+fi
+
+# Ensure the specified product is valud
+if [[ "$product" != "RTC_S1" && "$product" != "RTC_S1_STATIC" ]]; then
+  echo "Error: Invalid product '$product'."
+  echo "Allowed values: RTC_S1, RTC_S1_STATIC"
+  exit 1
 fi
 
 echo ""
 echo The input variables are:
 echo scene : "$scene"
+echo burst_ids : ${burst_ids[*]}
 echo resolution : "$resolution"
-echo output_crs : "$epsg_code"
+echo output_crs : "$epsg_code_msg"
 echo dem : "$dem"
+echo product : "$product"
 echo collection : "$collection"
 echo s3_bucket : "$s3_bucket"
 echo s3_project_folder : "$s3_project_folder"
@@ -66,8 +92,8 @@ echo ""
 
 # set process folders for the container
 download_folder="/home/rtc_user/working/downloads"
-out_folder="/home/rtc_user/working/results/$scene"
-scratch_folder="/home/rtc_user/working/scratch/$scene"
+out_folder="/home/rtc_user/working/results/$collection/$scene"
+scratch_folder="/home/rtc_user/working/scratch/$collection/$scene"
 
 echo The container will use these paths for processing:
 echo download_folder : "$out_folder"
@@ -81,16 +107,18 @@ source ~/.bashrc
 # activate the sar-pipeline environment 
 conda activate sar-pipeline
 
-# search and download all the required ancillery/src files 
+# search and download all the required ancillary/src files 
 # make the rtc config that will be used by the RTC processor
 # set the config path to be in the out_folder so it can be uploaded with products
 RUN_CONFIG_PATH="$out_folder/OPERA-RTC_runconfig.yaml"
 
 get-data-for-scene-and-make-run-config \
 --scene "$scene" \
+--burst_id_list ${burst_ids[*]} \
 --resolution "$resolution" \
 --output-crs "$output_crs" \
 --dem "$dem" \
+--product "$product" \
 --download-folder "$download_folder" \
 --scratch-folder "$scratch_folder" \
 --out-folder "$out_folder" \
@@ -101,7 +129,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# activate the ISCE3 envrionment and make products
+# activate the ISCE3 environment and make products
 conda activate RTC
 rtc_s1.py $RUN_CONFIG_PATH
 
@@ -113,11 +141,12 @@ fi
 # activate the sar-pipeline environment 
 conda activate sar-pipeline
 
-# point at the out product directory and make STAC metdata
+# point at the out product directory and make STAC metadata
 # note storage pattern is assumed to be s3_bucket / s3_project_folder / year / month / day / burst_id / *files
 make-rtc-opera-stac-and-upload-bursts \
 --results-folder "$out_folder" \
 --run-config-path "$RUN_CONFIG_PATH" \
+--product "$product" \
 --collection "$collection" \
 --s3-bucket "$s3_bucket" \
 --s3-project-folder "$s3_project_folder" 
@@ -126,7 +155,3 @@ if [ $? -ne 0 ]; then
     echo "Process failed: make-rtc-opera-stac-and-upload-bursts"
     exit 1
 fi
-
-
-
-


### PR DESCRIPTION
- Adding the ability to select between the production of two products `RTC_S1` and `RTC_S1_STATIC`
- The `--product` is defined at the top level of the workflow
- Adding the ability to specify a list of bursts_ids to process if desired, otherwise all bursts are processed. Specified through the `--burst_id_list` param
- A new .yaml config for the static layers added
- Updated / Improved documentation for workflow
-  Basic STAC metadata for the RTC_S1_STATIC layers
- Some TODOs are documented in the code:
      - Determine final STAC metadata
      - Determine how to link RTC_S1_STATIC layer products to each RTC_S1 product