### PR TITLE
Package version from git tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tests/sar_pipeline/data/**/*.json
 
 # ignore the burst_db project
 burst_db
+
+# ignore the version file made by setuptools_scm
+sar_pipeline/_version.py

--- a/pixi.lock
+++ b/pixi.lock
@@ -2934,8 +2934,8 @@ packages:
   requires_python: '>=3.8'
 - pypi: .
   name: sar-pipeline
-  version: '0.1'
-  sha256: ae4b53b466c28f90106ca8340e95250d2b65f95f92252f53647ee8a3782cd27f
+  version: 0.2.dev223+gf49c37d.d20250410
+  sha256: 7234a6ca1518fde39f50adc068db8dc92dd3953eeb86f5e2e1b86544bca7b731
   requires_dist:
   - asf-search>=8.1.1
   - boto3>=1.37.27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers=[
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
 ]
-version = "0.1" # TODO base this on files in project
+dynamic = ["version"]
 dependencies = [
     "asf-search>=8.1.1", 
     "boto3>=1.37.27", 
@@ -39,6 +39,9 @@ submit-pyrosar-gamma-workflow = "sar_pipeline.nci.cli:submit_pyrosar_gamma_workf
 upload-files-in-folder-to-s3 = "sar_pipeline.nci.cli:upload_files_in_folder_to_s3"
 get-data-for-scene-and-make-run-config = "sar_pipeline.aws.cli:get_data_for_scene_and_make_run_config"
 make-rtc-opera-stac-and-upload-bursts = "sar_pipeline.aws.cli:make_rtc_opera_stac_and_upload_bursts"
+
+[tool.setuptools_scm]
+version_file = "sar_pipeline/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/*"]

--- a/sar_pipeline/__init__.py
+++ b/sar_pipeline/__init__.py
@@ -1,0 +1,1 @@
+from sar_pipeline._version import __version__


### PR DESCRIPTION
- Package version is automatically set using the git tag.
- __init__ file explicitly links `__version__` from the `_version.py` file updated by setuptools

Example usage in python:

```python
import sar_pipeline
sar_pipeline.__version__
>> '0.2.dev223+gf49c37d.d20250410'
```

or 

```python
from importlib.metadata import version
version("sar-pipeline")
>> '0.2.dev223+gf49c37d.d20250410'
```