### PR TITLE
product skipping and general uplift

### DIFF
--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -421,7 +421,7 @@ def get_data_for_scene_and_make_run_config(
     "final path follows the patter in the description of this function.",
 )
 @click.option(
-    "--upload-to-s3",
+    "--skip-upload-to-s3",
     required=False,
     is_flag=True,
     default=False,
@@ -444,7 +444,7 @@ def make_rtc_opera_stac_and_upload_bursts(
     collection,
     s3_bucket,
     s3_project_folder,
-    upload_to_s3,
+    skip_upload_to_s3,
     link_static_layers,
 ):
     """makes STAC metadata for opera-rtc and uploads them to a desired s3 bucket.
@@ -500,10 +500,10 @@ def make_rtc_opera_stac_and_upload_bursts(
         # TODO validate the stac item when finalised
         # burst_stac_manager.item.validate()
         # push folder to S3
-        if upload_to_s3:
+        if skip_upload_to_s3:
+            logger.info(f"Skipping upload to S3.")
+        else:
             logger.info(f"uploading files for {burst_stac_manager.burst_id} to S3.")
             push_files_in_folder_to_s3(
                 burst_folder, s3_bucket, burst_stac_manager.burst_s3_subfolder
             )
-        else:
-            logger.info(f"Skipping upload to S3.")

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -108,8 +108,8 @@ logger = logging.getLogger(__name__)
     required=False,
     is_flag=True,
     default=False,
-    help="Skip the creating burst products if it already exist in the desired s3 bucket path. "
-    "Warning - false may result in duplicate products",
+    help="Skip creating the burst products if it already exist in the desired s3 bucket path. "
+    "Warning - setting this argument false may result in duplicate products",
 )
 @click.option(
     "--link-static-layers",

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -253,6 +253,7 @@ def get_data_for_scene_and_make_run_config(
         logging.warning(
             f"Products already exist for {len(existing_burst_ids)} of {len(burst_id_list)} requested bursts:"
         )
+        # iterate through existing products and show message with path
         for i in range(0, len(existing_burst_ids)):
             logger.warning(
                 f"Existing product : {existing_burst_ids[i]}, s3_path : {s3_bucket}/{existing_s3_paths[i]}"
@@ -261,9 +262,10 @@ def get_data_for_scene_and_make_run_config(
             # limit burst ids to those which haven't been processed
             burst_id_list = [b for b in burst_id_list if b not in existing_burst_ids]
             logger.warning(
-                "Skipping existing products. To create these, remove the existing products from S3. OR, do not pass flag "
-                "'--skip-existing-products'. Note this will create duplicates that may need to be handled downstream"
+                "Skipping the existing products. To create these, remove the existing products from S3. OR, do not pass flag "
+                "'--skip-existing-products' to workflow. Note this will create duplicates that may need to be handled downstream."
             )
+            # exit if all existing burst products exist
             if all(b in existing_burst_ids for b in burst_id_list):
                 logging.warning(
                     "All desired burst products already exist, exiting process early"
@@ -271,8 +273,8 @@ def get_data_for_scene_and_make_run_config(
                 sys.exit(100)
         else:
             logger.warning(
-                "Existing products are being created. Note this will create duplicates that may need to be handled downstream. "
-                "set '--skip-existing-products' if this is not desired."
+                "Existing products are being re-created. This will create duplicates in the S3 bucket that may need to be handled downstream. "
+                "set '--skip-existing-products' if this behavior is not desired."
             )
 
     logger.info(f"Processing {len(burst_id_list)} bursts for scene : {burst_id_list}")

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -263,7 +263,7 @@ def get_data_for_scene_and_make_run_config(
             burst_id_list = [b for b in burst_id_list if b not in existing_burst_ids]
             logger.warning(
                 "Skipping the existing products. To create these, remove the existing products from S3. OR, pass flag "
-                "'--make-existing-products' to workflow. Note this can create duplicates that may impact downstream processes."
+                "'--make-existing-products' to workflow. WARNING this can create duplicates that may impact downstream processes."
             )
             # exit if all existing burst products exist
             if all(b in existing_burst_ids for b in burst_id_list):

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -104,12 +104,12 @@ logger = logging.getLogger(__name__)
     help="Path to where the RTC/opera config wil be saved",
 )
 @click.option(
-    "--skip-existing-products",
+    "--make-existing-products",
     required=False,
     is_flag=True,
     default=False,
-    help="Skip creating the burst products if it already exist in the desired s3 bucket path. "
-    "Warning - setting this argument false may result in duplicate products",
+    help="Create the burst products even if they already exist in the desired s3 bucket path. "
+    "WARNING - setting this argument may result in duplicate files.",
 )
 @click.option(
     "--link-static-layers",
@@ -169,7 +169,7 @@ def get_data_for_scene_and_make_run_config(
     scratch_folder,
     out_folder,
     run_config_save_path,
-    skip_existing_products,
+    make_existing_products,
     link_static_layers,
     linked_static_layers_s3_bucket,
     linked_static_layers_collection,
@@ -258,12 +258,12 @@ def get_data_for_scene_and_make_run_config(
             logger.warning(
                 f"Existing product : {existing_burst_ids[i]}, s3_path : {s3_bucket}/{existing_s3_paths[i]}"
             )
-        if skip_existing_products:
+        if not make_existing_products:
             # limit burst ids to those which haven't been processed
             burst_id_list = [b for b in burst_id_list if b not in existing_burst_ids]
             logger.warning(
-                "Skipping the existing products. To create these, remove the existing products from S3. OR, do not pass flag "
-                "'--skip-existing-products' to workflow. Note this will create duplicates that may need to be handled downstream."
+                "Skipping the existing products. To create these, remove the existing products from S3. OR, pass flag "
+                "'--make-existing-products' to workflow. Note this can create duplicates that may impact downstream processes."
             )
             # exit if all existing burst products exist
             if all(b in existing_burst_ids for b in burst_id_list):
@@ -273,8 +273,8 @@ def get_data_for_scene_and_make_run_config(
                 sys.exit(100)
         else:
             logger.warning(
-                "Existing products are being re-created. This will create duplicates in the S3 bucket that may need to be handled downstream. "
-                "set '--skip-existing-products' if this behavior is not desired."
+                "Existing products are being re-created. WARNING This will create duplicates in the S3 bucket that may impact downstream processes. "
+                "set '--make-existing-products' if this behavior is not desired."
             )
 
     logger.info(f"Processing {len(burst_id_list)} bursts for scene : {burst_id_list}")

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -9,10 +9,15 @@ import requests
 import datetime
 import re
 import numpy as np
+import os
 
 import dem_handler
 import sar_pipeline
 from sar_pipeline.aws.metadata.h5 import H5Manager
+from sar_pipeline.aws.preparation.burst_utils import (
+    make_rtc_s1_s3_subpath,
+    make_rtc_s1_static_s3_subpath,
+)
 from sar_pipeline.utils.spatial import polygon_str_to_geojson, convert_bbox
 from sar_pipeline.aws.metadata.filetypes import (
     REQUIRED_ASSET_FILETYPES,
@@ -120,10 +125,22 @@ class BurstH5toStacManager:
         "make the s3 subfolder destination based on the product"
         if self.product == "RTC_S1":
             # include acquisition dates for S1_RTC
-            return f"{self.s3_project_folder}/{self.collection}/{self.burst_id}/{self.start_dt.year}/{self.start_dt.month}/{self.start_dt.day}"
+            return make_rtc_s1_s3_subpath(
+                s3_project_folder=self.s3_project_folder,
+                collection=self.collection,
+                burst_id=self.burst_id,
+                year=self.start_dt.year,
+                month=self.start_dt.month,
+                day=self.start_dt.day,
+            )
+
         if self.product == "RTC_S1_STATIC":
             # static products are date independent
-            return f"{self.s3_project_folder}/{self.collection}/{self.burst_id}"
+            return make_rtc_s1_static_s3_subpath(
+                s3_project_folder=self.s3_project_folder,
+                collection=self.collection,
+                burst_id=self.burst_id,
+            )
         else:
             raise ValueError()
 
@@ -514,9 +531,11 @@ class BurstH5toStacManager:
         achieved by reading in the STAC metadata file associated with the
         static layers themselves"""
 
-        static_layer_url = self.h5.search_value("staticLayersDataAccess")
-        burst_static_layer_stac_url = (
-            f"{static_layer_url}/{self.burst_id}/metadata.json"
+        static_layer_root_url = self.h5.search_value("staticLayersDataAccess")
+        # remove the index string which is used for user visibility
+        static_layer_url = static_layer_root_url.replace("index.html?prefix=", "")
+        burst_static_layer_stac_url = os.path.join(
+            static_layer_url, self.burst_id, "metadata.json"
         )
 
         try:
@@ -535,7 +554,7 @@ class BurstH5toStacManager:
         self.item.add_link(
             pystac.Link(
                 rel="static-layers",
-                target=f"burst_static_layer_stac_url",
+                target=burst_static_layer_stac_url,
             )
         )
 

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -203,6 +203,9 @@ class BurstH5toStacManager:
     def add_properties_from_h5(self):
         """Map required properties from the .h5 file"""
 
+        # add odc specific fields
+        self.item.properties["odc:product"] = self.collection
+
         # add product stac extension properties
         self.item.properties["product:type"] = self.product
         self.item.properties["product:timeliness_category"] = (

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -134,15 +134,13 @@ class BurstH5toStacManager:
                 day=self.start_dt.day,
             )
 
-        if self.product == "RTC_S1_STATIC":
+        elif self.product == "RTC_S1_STATIC":
             # static products are date independent
             return make_rtc_s1_static_s3_subpath(
                 s3_project_folder=self.s3_project_folder,
                 collection=self.collection,
                 burst_id=self.burst_id,
             )
-        else:
-            raise ValueError()
 
     def _extract_doi_link(self, text: str) -> str:
         """extracts the doi reference from a given string and converts

--- a/sar_pipeline/aws/preparation/burst_utils.py
+++ b/sar_pipeline/aws/preparation/burst_utils.py
@@ -235,6 +235,12 @@ def make_rtc_s1_s3_subpath(
         month of burst acquisition
     day : str
         day of burst acquisition
+
+    Returns
+    -------
+    str
+        path to the s3 bucket subfolder
+        e.g. my-subfolder/s1_rtc_c1/t028_059507_iw2/2022/01/01
     """
     return f"{s3_project_folder}/{collection}/{burst_id}/{year}/{month}/{day}"
 

--- a/sar_pipeline/utils/spatial.py
+++ b/sar_pipeline/utils/spatial.py
@@ -17,7 +17,6 @@ def polygon_str_to_geojson(polygon_str: str) -> dict:
     dict
         Geojson for the polygon
     """
-    logging.info(polygon_str)
     # Load and convert
     geometry = wkt.loads(polygon_str)
     geojson_feature = {

--- a/scripts/run_aws_pipeline.sh
+++ b/scripts/run_aws_pipeline.sh
@@ -11,7 +11,7 @@ product="RTC_S1"
 s3_bucket="deant-data-public-dev"
 s3_project_folder="experimental"
 collection="s1_rtc_c1"
-skip_existing_products=false
+make_existing_products=false
 skip_upload_to_s3=false
 ## -- WORKFLOW INPUTS TO LINK RTC_S1_STATIC in RTC_S1 metadata--
 # Assumes that a RTC_S1_STATIC products exist for all RTC_S1 bursts being processed
@@ -37,7 +37,7 @@ while [[ "$#" -gt 0 ]]; do
         --s3_bucket) s3_bucket="$2"; shift 2 ;;
         --s3_project_folder) s3_project_folder="$2"; shift 2 ;;
         --collection) collection="$2"; shift 2 ;;
-        --skip_existing_products) skip_existing_products=true; shift ;;
+        --make_existing_products) make_existing_products=true; shift ;;
         --skip_upload_to_s3) skip_upload_to_s3==true; shift ;;
         --link_static_layers) link_static_layers=true; shift ;;
         --linked_static_layers_s3_bucket) linked_static_layers_s3_bucket="$2"; shift 2 ;;
@@ -105,7 +105,7 @@ echo product : "$product"
 echo s3_bucket : "$s3_bucket"
 echo s3_project_folder : "$s3_project_folder"
 echo collection : "$collection"
-echo skip_existing_products : "$skip_existing_products"
+echo make_existing_products : "$make_existing_products"
 echo skip_upload_to_s3 : "$skip_upload_to_s3"
 echo scene_data_source : "$scene_data_source"
 echo orbit_data_source : "$orbit_data_source"
@@ -165,10 +165,10 @@ cmd=(
     --orbit-data-source "$orbit_data_source" \
 )
 
-if [ "$skip_existing_products" = true ] ; then
+if [ "$make_existing_products" = true ] ; then
     # make the product even if it already exists
     # WARNING - this may result in duplicates
-    cmd+=( --skip-existing-products )
+    cmd+=( --make-existing-products )
 fi
 if [ "$link_static_layers" = true ] ; then
     # Static layers ARE being linked in the stac metadata

--- a/scripts/run_aws_pipeline.sh
+++ b/scripts/run_aws_pipeline.sh
@@ -12,7 +12,7 @@ s3_bucket="deant-data-public-dev"
 s3_project_folder="experimental"
 collection="s1_rtc_c1"
 skip_existing_products=false
-upload_to_s3=true
+skip_upload_to_s3=false
 ## -- WORKFLOW INPUTS TO LINK RTC_S1_STATIC in RTC_S1 metadata--
 # Assumes that a RTC_S1_STATIC products exist for all RTC_S1 bursts being processed
 link_static_layers=false
@@ -38,7 +38,7 @@ while [[ "$#" -gt 0 ]]; do
         --s3_project_folder) s3_project_folder="$2"; shift 2 ;;
         --collection) collection="$2"; shift 2 ;;
         --skip_existing_products) skip_existing_products=true; shift ;;
-        --upload_to_s3) upload_to_s3="$2"; shift 2 ;;
+        --skip_upload_to_s3) skip_upload_to_s3="$2"; shift 2 ;;
         --link_static_layers) link_static_layers=true; shift ;;
         --linked_static_layers_s3_bucket) linked_static_layers_s3_bucket="$2"; shift 2 ;;
         --linked_static_layers_collection) linked_static_layers_collection="$2"; shift 2 ;;
@@ -106,7 +106,7 @@ echo s3_bucket : "$s3_bucket"
 echo s3_project_folder : "$s3_project_folder"
 echo collection : "$collection"
 echo skip_existing_products : "$skip_existing_products"
-echo upload_to_s3 : "$upload_to_s3"
+echo skip_upload_to_s3 : "$skip_upload_to_s3"
 echo scene_data_source : "$scene_data_source"
 echo orbit_data_source : "$orbit_data_source"
 
@@ -223,8 +223,8 @@ cmd=(
     --s3-project-folder "$s3_project_folder" 
 )
 
-if [ "$upload_to_s3" = true ] ; then
-    cmd+=( --upload-to-s3)
+if [ "$skip_upload_to_s3" = true ] ; then
+    cmd+=( --skip-upload-to-s3)
 fi
 if [ "$link_static_layers" = true ] ; then
     # Static layers are to be linked to RTC_S1 in the stac metadata

--- a/scripts/run_aws_pipeline.sh
+++ b/scripts/run_aws_pipeline.sh
@@ -38,7 +38,7 @@ while [[ "$#" -gt 0 ]]; do
         --s3_project_folder) s3_project_folder="$2"; shift 2 ;;
         --collection) collection="$2"; shift 2 ;;
         --skip_existing_products) skip_existing_products=true; shift ;;
-        --skip_upload_to_s3) skip_upload_to_s3="$2"; shift 2 ;;
+        --skip_upload_to_s3) skip_upload_to_s3==true; shift ;;
         --link_static_layers) link_static_layers=true; shift ;;
         --linked_static_layers_s3_bucket) linked_static_layers_s3_bucket="$2"; shift 2 ;;
         --linked_static_layers_collection) linked_static_layers_collection="$2"; shift 2 ;;


### PR DESCRIPTION
- Adding`--skip-existing-products` flag to search and skip products if they already exist in s3 
- The process will now gracefully exit if all requested products already exist
- Adding `--skip-upload-to-s3` to specify skipping the upload to s3 alone
- consolidating logic for creating paths to products in s3
- rename flag `dem` to `dem_type`