### PR TITLE
Upgrade/improve product exists logic

### DIFF
--- a/sar_pipeline/__init__.py
+++ b/sar_pipeline/__init__.py
@@ -1,1 +1,4 @@
 from sar_pipeline._version import __version__
+import asf_search
+
+asf_search.constants.INTERNAL.CMR_TIMEOUT = 90

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -330,6 +330,11 @@ def get_data_for_scene_and_make_run_config(
         logger.warning("The scene crosses the antimeridian, correcting bounds")
         bounds = get_correct_bounds_from_shape_at_antimeridian(scene_polygon)
         logger.info(f"The scene bounds are : {bounds}")
+        # increase the buffer to ensure DEM sufficiently covers area
+        # shape is a little odd due to merging either side of AM
+        cop30_buffer_degrees = 0.8
+    else:
+        cop30_buffer_degrees = 0.3
 
     logger.info(f"Downloading DEM type `{dem_type}` to path : {DEM_PATH}")
     if dem_type == "cop_glo30":
@@ -339,7 +344,7 @@ def get_data_for_scene_and_make_run_config(
             ellipsoid_heights=True,
             adjust_at_high_lat=True,
             buffer_pixels=None,
-            buffer_degrees=0.3,
+            buffer_degrees=cop30_buffer_degrees,
             cop30_folder_path=dem_folder,
             geoid_tif_path=dem_folder / f"{scene}_geoid.tif",
             download_dem_tiles=True,

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -241,26 +241,42 @@ def get_data_for_scene_and_make_run_config(
         )
 
     elif scene_data_source == "CDSE":
-        # burst information must be taken from a downloaded scene
-        logger.info(f"Downloading SLC for scene : {scene}")
-        SCENE_PATH, cdse_scene_metadata = download_slc_from_cdse(scene, scene_folder)
-        scene_polygon = shape(cdse_scene_metadata["geometry"])
-        polarisation_list = cdse_scene_metadata["properties"]["polarisation"].split("&")
-        input_scene_url = cdse_scene_metadata["properties"]["services"]["download"][
-            "url"
-        ]
-        # get burst data from the downloaded slc
-        slc_bursts_info = []
-        logger.info(f"Getting burst information from the downloaded scene slc file")
-        logger.info(f"Scene polarisations : {polarisation_list}")
-        for pol in polarisation_list:
-            slc_bursts_info += s1_info.get_bursts(SCENE_PATH, pol=pol.lower())
-            all_slc_burst_id_list = [str(b.burst_id) for b in slc_bursts_info]
-            all_slc_burst_st_list = [b.sensing_start for b in slc_bursts_info]
+        try:
+            # try to find bursts on ASF first so download is not done until required
+            logger.info(f"Querying ASF for scene burst id's")
+            all_slc_burst_id_list, all_slc_burst_st_list = (
+                get_burst_ids_and_start_times_for_scene_from_asf(scene)
+            )
+            logger.info(
+                f"{len(all_slc_burst_id_list)} burst ids found for scene from ASF API"
+            )
+            SCENE_PATH = None  # set flag so we know to download
+        except FileExistsError:
+            logger.info(f"Burst id's not found on ASF, downloading scene from CDSE")
+            # burst information must be taken from a downloaded scene
+            logger.info(f"Downloading SLC for scene : {scene}")
+            SCENE_PATH, cdse_scene_metadata = download_slc_from_cdse(
+                scene, scene_folder
+            )
+            scene_polygon = shape(cdse_scene_metadata["geometry"])
+            polarisation_list = cdse_scene_metadata["properties"]["polarisation"].split(
+                "&"
+            )
+            input_scene_url = cdse_scene_metadata["properties"]["services"]["download"][
+                "url"
+            ]
+            # get burst data from the downloaded slc
+            slc_bursts_info = []
+            logger.info(f"Getting burst information from the downloaded scene slc file")
+            logger.info(f"Scene polarisations : {polarisation_list}")
+            for pol in polarisation_list:
+                slc_bursts_info += s1_info.get_bursts(SCENE_PATH, pol=pol.lower())
+                all_slc_burst_id_list = [str(b.burst_id) for b in slc_bursts_info]
+                all_slc_burst_st_list = [b.sensing_start for b in slc_bursts_info]
 
-        logger.info(
-            f"{len(all_slc_burst_id_list)} burst ids found for scene in the slc"
-        )
+            logger.info(
+                f"{len(all_slc_burst_id_list)} burst ids found for scene in the slc"
+            )
 
     # Limit the bursts to be processed if a list has been provided
     if burst_id_list:
@@ -309,6 +325,15 @@ def get_data_for_scene_and_make_run_config(
         scene_polygon = shape(asf_scene_metadata.geometry)
         polarisation_list = asf_scene_metadata.properties["polarization"].split("+")
         input_scene_url = asf_scene_metadata.properties["url"]
+
+    elif scene_data_source == "CDSE" and SCENE_PATH is None:
+        logger.info(f"Downloading SLC for scene : {scene}")
+        SCENE_PATH, cdse_scene_metadata = download_slc_from_cdse(scene, scene_folder)
+        scene_polygon = shape(cdse_scene_metadata["geometry"])
+        polarisation_list = cdse_scene_metadata["properties"]["polarisation"].split("&")
+        input_scene_url = cdse_scene_metadata["properties"]["services"]["download"][
+            "url"
+        ]
 
     # # download the orbits
     logger.info(f"Downloading Orbits for scene : {scene}")

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -288,6 +288,9 @@ def get_data_for_scene_and_make_run_config(
         collection=collection,
         make_existing_products=make_existing_products,
     )
+
+    logger.info(f"Processing {len(burst_id_list)} bursts for scene : {burst_id_list}")
+
     # to link the RTC_S1_STATIC layers to RTC_S1, the static layers must already exist
     if link_static_layers and product == "RTC_S1":
         logger.info(f"Checking static layers exist for bursts in scene : {scene}")
@@ -306,8 +309,6 @@ def get_data_for_scene_and_make_run_config(
         scene_polygon = shape(asf_scene_metadata.geometry)
         polarisation_list = asf_scene_metadata.properties["polarization"].split("+")
         input_scene_url = asf_scene_metadata.properties["url"]
-
-    logger.info(f"Processing {len(burst_id_list)} bursts for scene : {burst_id_list}")
 
     # # download the orbits
     logger.info(f"Downloading Orbits for scene : {scene}")

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -382,6 +382,7 @@ def get_data_for_scene_and_make_run_config(
             bounds_src_crs=4326,
             save_path=DEM_PATH,
             resolution=dem_resolution,
+            buffer_pixels=500,
             ellipsoid_heights=True,
             download_geoid=True,
             geoid_tif_path=dem_folder / f"{scene}_geoid.tif",

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -507,7 +507,8 @@ def make_rtc_opera_stac_and_upload_bursts(
         burst_h5_files = list(burst_folder.glob("*.h5"))
         if len(burst_h5_files) != 1:
             raise ValueError(
-                f"{len(burst_h5_files)} .h5 files found. Expecting 1 in : {burst_folder}"
+                f"{len(burst_h5_files)} .h5 files found. Expecting 1 in : {burst_folder}."
+                f"This error might be caused by repeat runs. Delete duplicate files or change run setings."
             )
         burst_h5_filepath = burst_folder / burst_h5_files[0]
         # make the stac metadata from the .h5 metadata
@@ -532,7 +533,7 @@ def make_rtc_opera_stac_and_upload_bursts(
         # add links that can change
         burst_stac_manager.add_dynamic_links_from_h5()
         # add the link to self/metadata
-        if link_static_layers:
+        if link_static_layers and product == "RTC_S1":
             # link to static layer metadata is in the .h5 file
             # use this to map assets to the file
             burst_stac_manager.add_linked_static_layer_assets_and_link()

--- a/sar_pipeline/aws/preparation/burst_utils.py
+++ b/sar_pipeline/aws/preparation/burst_utils.py
@@ -71,7 +71,7 @@ def find_s3_filepaths_from_suffixes(bucket_name, s3_folder, suffixes) -> dict:
 
 
 def get_burst_ids_and_start_times_for_scene_from_asf(
-    scene: str, burst_prefix: str = "t", lowercase=True
+    scene: str, burst_prefix: str = "t", lowercase: bool = True
 ) -> tuple[list[str], list[datetime]]:
     """Get the list of burst_ids corresponding to a scene
 

--- a/sar_pipeline/aws/preparation/burst_utils.py
+++ b/sar_pipeline/aws/preparation/burst_utils.py
@@ -5,6 +5,7 @@ import os
 import logging
 import s1reader
 from typing import Literal
+import sys
 
 from sar_pipeline.aws.metadata.filetypes import REQUIRED_ASSET_FILETYPES
 from sar_pipeline.nci.preparation.scenes import parse_scene_file_dates
@@ -69,9 +70,9 @@ def find_s3_filepaths_from_suffixes(bucket_name, s3_folder, suffixes) -> dict:
     return suffix_to_s3path
 
 
-def get_burst_ids_for_scene_from_asf(
+def get_burst_ids_and_start_times_for_scene_from_asf(
     scene: str, burst_prefix: str = "t", lowercase=True
-) -> list[str]:
+) -> tuple[list[str], list[datetime]]:
     """Get the list of burst_ids corresponding to a scene
 
     Parameters
@@ -84,10 +85,16 @@ def get_burst_ids_for_scene_from_asf(
     lowercase: bool
         convert the burst to lowercase. default to True to match workflow output.
 
+    Raises
+    -------
+    FileExistsError:
+        The scene does not exist on the ASF.
+
     Returns
     -------
-    list[str]
+    tuple[list[str],list[datetime]]
         List of burst ids. e.g. ['t070_149822_IW3','t070_149822_IW2' ....]
+        List of sensing start times corresponding to each above burst ids.
     """
 
     st, et = parse_scene_file_dates(scene)
@@ -105,10 +112,21 @@ def get_burst_ids_for_scene_from_asf(
         for b in results
         if scene in b.properties["url"]
     ]
+    burst_sts = [
+        datetime.strptime(b.properties["startTime"], "%Y-%m-%dT%H:%M:%SZ")
+        for b in results
+        if scene in b.properties["url"]
+    ]
     if lowercase:
         burst_ids = [b.lower() for b in burst_ids]
 
-    return burst_ids
+    if len(burst_ids) == 0:
+        raise FileExistsError(
+            "No burst id's for scene could be found on the ASF. Ensure input values are correct "
+            "or set `--scene_data_source CDSE` as recent scenes may not be available on ASF, or the scene is missing"
+        )
+
+    return burst_ids, burst_sts
 
 
 def make_static_layer_base_url(
@@ -149,10 +167,12 @@ def make_static_layer_base_url(
 
 def check_burst_products_exists_in_s3(
     product: Literal["RTC_S1", "RTC_S1_STATIC"],
-    slc_bursts_info: list[s1reader.Sentinel1BurstSlc],
+    burst_id_list: list[str],
+    burst_st_list: list[str],
     s3_bucket: str,
     s3_project_folder: str,
     collection: str,
+    make_existing_products: bool,
 ) -> tuple[list[str], list[str]]:
     """Check if the product already exists in s3. The storage location differs
     for static layers (RTC_S1_STATIC) and backscatter (RTC_S1). This function checks
@@ -162,14 +182,19 @@ def check_burst_products_exists_in_s3(
     ----------
     product : str
         Product being created, either 'RTC_S1' or 'RTC_S1_STATIC'
-    slc_bursts_info : list[s1reader.Sentinel1BurstSlc]
-        List of s1reader burst classes containing information for each burst
+    burst_id_list : list[str]
+        List of burst ids
+    burst_st_list : list[str]
+        List of start-times corresponding to each burst id
     s3_bucket : str
         The bucket where the products are stored
     s3_project_folder : str
         The subpath within the bucket
     collection : str
         The collection. e.f. rtc_s1_c1
+    make_existing_products : bool
+        whether to make products if they already exist in s3. If False,
+        process will exit early if all already exist.
 
     Returns
     -------
@@ -182,32 +207,59 @@ def check_burst_products_exists_in_s3(
     existing_burst_ids = []
     existing_s3_paths = []
 
-    for burst in slc_bursts_info:
+    for burst_id, burst_st in zip(burst_id_list, burst_st_list):
         if product == "RTC_S1_STATIC":
             s3_product_subpath = make_rtc_s1_static_s3_subpath(
                 s3_project_folder=s3_project_folder,
                 collection=collection,
-                burst_id=str(burst.burst_id),
+                burst_id=burst_id,
             )
         if product == "RTC_S1":
-            sensing_start = burst.sensing_start
             s3_product_subpath = make_rtc_s1_s3_subpath(
                 s3_project_folder=s3_project_folder,
                 collection=collection,
-                burst_id=str(burst.burst_id),
-                year=sensing_start.year,
-                month=sensing_start.month,
-                day=sensing_start.day,
+                burst_id=burst_id,
+                year=burst_st.year,
+                month=burst_st.month,
+                day=burst_st.day,
             )
         # assume the product exists if there is a .h5 file
         product_h5_files = find_s3_filepaths_from_suffixes(
             bucket_name=s3_bucket, s3_folder=s3_product_subpath, suffixes=[".h5"]
         )
         if len(product_h5_files[".h5"]) > 0:
-            existing_burst_ids.append(str(burst.burst_id))
+            existing_burst_ids.append(burst_id)
             existing_s3_paths.append(s3_product_subpath)
 
-    return existing_burst_ids, existing_s3_paths
+    if len(existing_burst_ids) > 0:
+        logging.warning(
+            f"Products already exist for {len(existing_burst_ids)} of {len(burst_id_list)} requested bursts:"
+        )
+        # iterate through existing products and show message with path
+        for i in range(0, len(existing_burst_ids)):
+            logger.warning(
+                f"Existing product : {existing_burst_ids[i]}, s3_path : {s3_bucket}/{existing_s3_paths[i]}"
+            )
+        if not make_existing_products:
+            # limit burst ids to those which haven't been processed
+            burst_id_list = [b for b in burst_id_list if b not in existing_burst_ids]
+            logger.warning(
+                "Skipping the existing products. To create these, remove the existing products from S3. OR, pass flag "
+                "'--make-existing-products' to workflow. WARNING this can create duplicates that may impact downstream processes."
+            )
+            # exit if all existing burst products exist
+            if all(b in existing_burst_ids for b in burst_id_list):
+                logging.warning(
+                    "All desired burst products already exist, exiting process early"
+                )
+                sys.exit(100)
+        else:
+            logger.warning(
+                "Existing products are being re-created. WARNING This will create duplicates in the S3 bucket that may impact downstream processes. "
+                "set '--make-existing-products' if this behavior is not desired."
+            )
+
+    return burst_id_list
 
 
 def make_rtc_s1_s3_subpath(

--- a/sar_pipeline/aws/preparation/burst_utils.py
+++ b/sar_pipeline/aws/preparation/burst_utils.py
@@ -401,6 +401,8 @@ def check_static_layers_in_s3(
             f"{n_missing} of {n_bursts} required bursts have files missing.\n"
             f"Missing Bursts and static layer filetypes:\n"
             f"{missing_info}\n"
-            f"Example path searched : {static_layers_s3_folder}\n"
-            f"Check S3 linked location settings or create missing static layers using --product RTC_S1_STATIC. See workflow docs for details."
+            f"Example AWS S3 path searched : {static_layers_s3_bucket}/{static_layers_s3_folder}\n"
+            f"Check linked location arguments or create the missing static layers. "
+            f"E.g. re-run the workflow using `--product RTC_S1_STATIC --collection rtc_s1_static_c1.`\n"
+            f"See workflow docs for details at docs/workflows/aws.md."
         )

--- a/sar_pipeline/aws/preparation/orbits.py
+++ b/sar_pipeline/aws/preparation/orbits.py
@@ -122,4 +122,4 @@ def download_orbits(
         raise ValueError(
             f"{len(ORBIT_PATHS)} orbit paths found for scene. Expecting 1."
         )
-    return ORBIT_PATHS
+    return orbit_paths

--- a/sar_pipeline/aws/preparation/orbits.py
+++ b/sar_pipeline/aws/preparation/orbits.py
@@ -108,7 +108,7 @@ def download_orbits(
     logger.info(f"Starting EOF download from {source}...")
 
     # The logic in eof.download.main() tries CDSE first by default. set force_asf by source
-    ORBIT_PATHS = eof.download.main(
+    orbit_paths = eof.download.main(
         sentinel_file=sentinel_file,
         save_dir=save_dir,
         cdse_user=cdse_user,

--- a/sar_pipeline/aws/preparation/orbits.py
+++ b/sar_pipeline/aws/preparation/orbits.py
@@ -118,7 +118,7 @@ def download_orbits(
         asf_password=asf_password,
     )
 
-    if len(ORBIT_PATHS) > 1:
+    if len(orbit_paths) > 1:
         raise ValueError(
             f"{len(ORBIT_PATHS)} orbit paths found for scene. Expecting 1."
         )

--- a/sar_pipeline/aws/preparation/orbits.py
+++ b/sar_pipeline/aws/preparation/orbits.py
@@ -108,7 +108,7 @@ def download_orbits(
     logger.info(f"Starting EOF download from {source}...")
 
     # The logic in eof.download.main() tries CDSE first by default. set force_asf by source
-    return eof.download.main(
+    ORBIT_PATHS = eof.download.main(
         sentinel_file=sentinel_file,
         save_dir=save_dir,
         cdse_user=cdse_user,
@@ -117,3 +117,9 @@ def download_orbits(
         asf_user=asf_user,
         asf_password=asf_password,
     )
+
+    if len(ORBIT_PATHS) > 1:
+        raise ValueError(
+            f"{len(ORBIT_PATHS)} orbit paths found for scene. Expecting 1."
+        )
+    return ORBIT_PATHS


### PR DESCRIPTION
Main Changes
- Changing logic to first check if the burst files already exist in S3, and stopping the process early if the do (unless `make_existing_products` is set)
- This is changed from the previous logic which will always download a scene first
- This can only be implemented when `--scene_data_source ASF` is set, as the burst_id's for a given scene cannot be queried from the CDSE (It seems the burst_id in the format of `t012_025211_iw2` is an ASF thing. Thus, `--scene_data_source CDSE` will still download the scene before checking if the burst products exist
- The change is important for the production of the `RTC_S1_STATIC` layers. We can now run a large time period with little overhead to ensure all of the required static layers are created.

Other
- increased ASF timeout to 90s from default of 30s
- Cleaning up error codes and shuffling some stuff out of the main cli