### PR TITLE
Alter download scene functions to work from scene ID

### DIFF
--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -8,8 +8,8 @@ from s1reader import s1_info
 import re
 
 from sar_pipeline.aws.preparation.scenes import (
-    download_slc_from_asf,
-    download_slc_from_cdse,
+    download_scene_from_asf,
+    download_scene_from_cdse,
 )
 from sar_pipeline.aws.preparation.orbits import download_orbits
 from sar_pipeline.aws.preparation.burst_utils import (
@@ -232,12 +232,12 @@ def get_data_for_scene_and_make_run_config(
     logger.info(f"Downloading SLC for scene : {scene}")
 
     if scene_data_source == "ASF":
-        SCENE_PATH, asf_scene_metadata = download_slc_from_asf(scene, scene_folder)
+        SCENE_PATH, asf_scene_metadata = download_scene_from_asf(scene, scene_folder)
         scene_polygon = shape(asf_scene_metadata.geometry)
         polarisation_list = asf_scene_metadata.properties["polarization"].split("+")
         input_scene_url = asf_scene_metadata.properties["url"]
     if scene_data_source == "CDSE":
-        SCENE_PATH, cdse_scene_metadata = download_slc_from_cdse(scene, scene_folder)
+        SCENE_PATH, cdse_scene_metadata = download_scene_from_cdse(scene, scene_folder)
         scene_polygon = shape(cdse_scene_metadata["geometry"])
         polarisation_list = cdse_scene_metadata["properties"]["polarisation"].split("&")
         input_scene_url = cdse_scene_metadata["properties"]["services"]["download"][

--- a/sar_pipeline/aws/preparation/scenes.py
+++ b/sar_pipeline/aws/preparation/scenes.py
@@ -1,14 +1,16 @@
 import asf_search
+from asf_search import ASFSearchResults
 import os
 from pathlib import Path
 import logging
 import zipfile
-from cdsetool.query import query_features
+from cdsetool.query import query_features, FeatureQuery
 from cdsetool.credentials import Credentials
 from cdsetool.download import download_features
 from cdsetool.monitor import StatusMonitor
 
 from sar_pipeline.utils.general import log_timing
+from sar_pipeline.utils.sentinel1 import extract_metadata_from_s1_id
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -20,8 +22,35 @@ class MissingCredentialsError(Exception):
     pass
 
 
+def query_scene_from_asf(scene: str) -> ASFSearchResults:
+
+    logger.info(f"Searching ASF for scene")
+
+    # Extract metadata from scene ID
+    scene_metadata = extract_metadata_from_s1_id(scene)
+
+    # Determine the asf_search product type to search: https://github.com/asfadmin/Discovery-asf_search/blob/master/asf_search/constants/PRODUCT_TYPE.py
+    # GRD processingly level query cannot currently be determined from product type alone, so list all GRD and assume it is one of these five.
+    # The list is sufficient to distinguish metadata files from data files
+    if scene_metadata["product_type"] == "GRD":
+        processing_level_query = ["GRD_HD", "GRD_MD", "GRD_MS", "GRD_HS", "GRD_FD"]
+    elif scene_metadata["product_type"] in ["SLC", "OCN", "RAW"]:
+        processing_level_query = scene_metadata["product_type"]
+    else:
+        raise ValueError(
+            f"Product type {scene_metadata["product_type"]} not recognised. Should be one of GRD, SLC, OCN, or RAW"
+        )
+
+    # Run the search
+    search_results = asf_search.granule_search(
+        [scene], asf_search.ASFSearchOptions(processingLevel=processing_level_query)
+    )
+
+    return search_results
+
+
 @log_timing
-def download_slc_from_asf(
+def download_scene_from_asf(
     scene: str,
     download_folder: Path,
     make_folder: bool = True,
@@ -30,11 +59,8 @@ def download_slc_from_asf(
     asf_pass: str | None = None,
 ):
 
-    logger.info(f"Searching ASF for scene")
-
-    search_results = asf_search.granule_search(
-        [scene], asf_search.ASFSearchOptions(processingLevel="SLC")
-    )
+    # Search for scene on ASF
+    search_results = query_scene_from_asf(scene)
 
     # ensure only one slc found
     if len(search_results) != 1:
@@ -83,8 +109,22 @@ def download_slc_from_asf(
         return scene_zip_path, asf_scene_metadata
 
 
+def query_scene_from_cdse(scene: str) -> FeatureQuery:
+
+    logger.info(f"Searching CDSE for scene")
+
+    features = query_features(
+        "Sentinel1",
+        {
+            "productIdentifier": scene,
+        },
+    )
+
+    return features
+
+
 @log_timing
-def download_slc_from_cdse(
+def download_scene_from_cdse(
     scene: str,
     download_folder: Path,
     make_folder: bool = True,
@@ -107,20 +147,13 @@ def download_slc_from_cdse(
     if make_folder:
         os.makedirs(download_folder, exist_ok=True)
 
-    logger.info(f"Searching CDSE for scene")
-
-    features = query_features(
-        "Sentinel1",
-        {
-            "processingLevel": "LEVEL1",
-            "sensorMode": "IW",
-            "productType": "IW_SLC__1S",
-            "productIdentifier": scene,
-        },
-    )
+    # search for scene on CDSE
+    features = query_scene_from_cdse(scene)
 
     if len(features) != 1:
-        raise ValueError(f"Expected 1 SLC, found {len(features)} for scene : {scene}")
+        raise ValueError(
+            f"Expected 1 scene, found {len(features)} for scene id : {scene}"
+        )
 
     scene_zip_path = Path(download_folder) / f"{scene}.SAFE.zip"
     scene_safe_path = scene_zip_path.with_suffix("")

--- a/sar_pipeline/utils/sentinel1.py
+++ b/sar_pipeline/utils/sentinel1.py
@@ -2,21 +2,47 @@ import re
 
 # Taken from https://sentiwiki.copernicus.eu/web/s1-products#S1Products-SARNamingConventionS1-Products-SAR-Naming-Convention
 SENTINEL_1_ID_PATTERN = (
-    r"^S1[ABC]_"  # MMM: S1A, S1B, S1C
+    r"(S1[ABC])_"  # MMM: S1A, S1B, S1C
     r"(S1|S2|S3|S4|S5|S6|IW|EW|WV|EN|N[1-6]|Z[IEW1-6])_"  # BB: Beam identifiers
     r"(RAW|SLC|GRD|OCN|ETA)"  # TTT: Product Type
-    r"[FHM_]_"  # R: Resolution class
-    r"[012A]"  # L: Processing level
-    r"[SANCX]"  # F: Product class
+    r"([FHM_])_"  # R: Resolution class
+    r"([012A])"  # L: Processing level
+    r"([SANCX])"  # F: Product class
     r"(SH|SV|DH|DV|HH|HV|VV|VH)_"  # PP: Polarisation
-    r"\d{8}T\d{6}_"  # Start datetime
-    r"\d{8}T\d{6}_"  # Stop datetime
-    r"\d{6}_"  # Orbit number (000000–999999)
-    r"(?!000000)[A-F0-9]{6}_"  # Data-take ID: non-zero hex
-    r"[A-F0-9]{4}"  # CRC16 and extension
+    r"(\d{8}T\d{6})_"  # Start datetime
+    r"(\d{8}T\d{6})_"  # Stop datetime
+    r"(\d{6})_"  # Orbit number (000000–999999)
+    r"((?!000000)[A-F0-9]{6})_"  # Data-take ID: non-zero hex
+    r"([A-F0-9]{4})"  # CRC16 and extension
 )
 
-SENTINEL_1_FILE_PATTERN = SENTINEL_1_ID_PATTERN + r"\.SAFE$"
+SENTINEL_1_FILE_PATTERN = SENTINEL_1_ID_PATTERN + r"\.SAFE"
+
+
+def extract_metadata_from_s1_id(id: str) -> dict[str, str]:
+    match = re.compile(SENTINEL_1_ID_PATTERN).match(id)
+
+    if match is not None:
+        metadata_dict = {
+            "mission": match.group(1),
+            "beam_mode": match.group(2),
+            "product_type": match.group(3),
+            "resolution_class": match.group(4),
+            "processing_level": match.group(5),
+            "product_class": match.group(6),
+            "polarisation": match.group(7),
+            "start_datetime": match.group(8),
+            "stop_datetime": match.group(9),
+            "absolute_orbit_number": match.group(10),
+            "mission_data_take": match.group(11),
+            "product_uid": match.group(12),
+        }
+    else:
+        raise ValueError(
+            "Match was unsuccessful. Check that input is a valid Sentinel-1 ID"
+        )
+
+    return metadata_dict
 
 
 def is_s1_id(id: str) -> bool:

--- a/tests/sar_pipeline/test_scenes.py
+++ b/tests/sar_pipeline/test_scenes.py
@@ -3,6 +3,15 @@ from sar_pipeline.nci.preparation.scenes import (
     parse_scene_file_dates,
     parse_scene_file_sensor,
 )
+from sar_pipeline.aws.preparation.scenes import (
+    query_scene_from_asf,
+    query_scene_from_cdse,
+)
+from sar_pipeline.utils.sentinel1 import (
+    is_s1_filename,
+    is_s1_id,
+    extract_metadata_from_s1_id,
+)
 
 import dataclasses
 from datetime import datetime
@@ -13,41 +22,141 @@ import pytest
 @dataclasses.dataclass
 class Scene:
     id: str
-    file: Path
-    sensor: str
-    start_date: datetime
-    stop_date: datetime
+    mission: str
+    beam_mode: str
+    product_type: str
+    resolution_class: str
+    processing_level: str
+    product_class: str
+    polarisation: str
+    start_date: str
+    stop_date: str
+    absolute_orbit_number: str
+    mission_data_take: str
+    product_uid: str
+
+    @property
+    def start_date_datetime(self) -> datetime:
+        return datetime.strptime(self.start_date, "%Y%m%dT%H%M%S")
+
+    @property
+    def stop_date_datetime(self) -> datetime:
+        return datetime.strptime(self.stop_date, "%Y%m%dT%H%M%S")
 
 
 scene_1 = Scene(
     id="S1A_EW_GRDM_1SDH_20200330T165825_20200330T165929_031907_03AF02_8570",
-    file=Path(
-        "/g/data/fj7/Copernicus/Sentinel-1/C-SAR/GRD/2020/2020-03/70S050E-75S055E/S1A_EW_GRDM_1SDH_20200330T165825_20200330T165929_031907_03AF02_8570.zip"
-    ),
-    sensor="S1A",
-    start_date=datetime(2020, 3, 30, 16, 58, 25),
-    stop_date=datetime(2020, 3, 30, 16, 59, 29),
+    mission="S1A",
+    beam_mode="EW",
+    product_type="GRD",
+    resolution_class="M",
+    processing_level="1",
+    product_class="S",
+    polarisation="DH",
+    start_date="20200330T165825",
+    stop_date="20200330T165929",
+    absolute_orbit_number="031907",
+    mission_data_take="03AF02",
+    product_uid="8570",
 )
 
 scene_2 = Scene(
     id="S1B_EW_GRDM_1SDH_20210914T112333_20210914T112403_028693_036C96_3EA8",
-    file=Path(
-        "/g/data/fj7/Copernicus/Sentinel-1/C-SAR/GRD/2021/2021-09/60S120E-65S125E/S1B_EW_GRDM_1SDH_20210914T112333_20210914T112403_028693_036C96_3EA8.zip"
-    ),
-    sensor="S1B",
-    start_date=datetime(2021, 9, 14, 11, 23, 33),
-    stop_date=datetime(2021, 9, 14, 11, 24, 3),
+    mission="S1B",
+    beam_mode="EW",
+    product_type="GRD",
+    resolution_class="M",
+    processing_level="1",
+    product_class="S",
+    polarisation="DH",
+    start_date="20210914T112333",
+    stop_date="20210914T112403",
+    absolute_orbit_number="028693",
+    mission_data_take="036C96",
+    product_uid="3EA8",
 )
 
-scenes = [scene_1, scene_2]
+scene_3 = Scene(
+    id="S1B_IW_SLC__1SSH_20211216T123605_20211216T123634_030050_03968D_9501",
+    mission="S1B",
+    beam_mode="IW",
+    product_type="SLC",
+    resolution_class="_",
+    processing_level="1",
+    product_class="S",
+    polarisation="SH",
+    start_date="20211216T123605",
+    stop_date="20211216T123634",
+    absolute_orbit_number="030050",
+    mission_data_take="03968D",
+    product_uid="9501",
+)
+
+scene_4 = Scene(
+    id="S1A_IW_SLC__1SDV_20240109T195221_20240109T195248_052034_0649D6_1FF6",
+    mission="S1A",
+    beam_mode="IW",
+    product_type="SLC",
+    resolution_class="_",
+    processing_level="1",
+    product_class="S",
+    polarisation="DV",
+    start_date="20240109T195221",
+    stop_date="20240109T195248",
+    absolute_orbit_number="052034",
+    mission_data_take="0649D6",
+    product_uid="1FF6",
+)
+
+scenes = [scene_1, scene_2, scene_3, scene_4]
 
 
 @pytest.mark.parametrize("scene", scenes)
 def test_parse_scene_file_dates(scene: Scene):
-    date_tuple = (scene.start_date, scene.stop_date)
+    date_tuple = (scene.start_date_datetime, scene.stop_date_datetime)
     assert parse_scene_file_dates(scene.id) == date_tuple
 
 
 @pytest.mark.parametrize("scene", scenes)
 def test_parse_scene_file_sensor(scene: Scene):
-    assert parse_scene_file_sensor(scene.id) == scene.sensor
+    assert parse_scene_file_sensor(scene.id) == scene.mission
+
+
+@pytest.mark.parametrize("scene", scenes)
+def test_query_scene_from_asf(scene: Scene):
+    query_result = query_scene_from_asf(scene.id)
+    assert len(query_result) == 1
+
+
+@pytest.mark.parametrize("scene", scenes)
+def test_query_scene_from_cdse(scene: Scene):
+    query_result = query_scene_from_cdse(scene.id)
+    assert len(query_result) == 1
+
+
+@pytest.mark.parametrize("scene", scenes)
+def test_is_s1_id(scene: Scene):
+    assert is_s1_id(scene.id)
+
+
+@pytest.mark.parametrize("scene", scenes)
+def test_is_s1_filename(scene: Scene):
+    scene_filename = scene.id + ".SAFE"
+    assert is_s1_filename(scene_filename)
+
+
+@pytest.mark.parametrize("scene", scenes)
+def test_extract_metadata_from_s1_id(scene: Scene):
+    metadata_dict = extract_metadata_from_s1_id(scene.id)
+    assert metadata_dict["mission"] == scene.mission
+    assert metadata_dict["beam_mode"] == scene.beam_mode
+    assert metadata_dict["product_type"] == scene.product_type
+    assert metadata_dict["resolution_class"] == scene.resolution_class
+    assert metadata_dict["processing_level"] == scene.processing_level
+    assert metadata_dict["product_class"] == scene.product_class
+    assert metadata_dict["polarisation"] == scene.polarisation
+    assert metadata_dict["start_datetime"] == scene.start_date
+    assert metadata_dict["stop_datetime"] == scene.stop_date
+    assert metadata_dict["absolute_orbit_number"] == scene.absolute_orbit_number
+    assert metadata_dict["mission_data_take"] == scene.mission_data_take
+    assert metadata_dict["product_uid"] == scene.product_uid


### PR DESCRIPTION
This update converts the `download_slc_from_asf` and `download_slc_from_cdse` to more generic versions of the functions that read the metadata contained in the provided ID and downloads the file.

This includes separating out the query step (which does not require credentials) into its own function so that it can be easily tested. 

This allows us to download GRD files as well as SLC files, which is valuable for EW processing.