### PR TITLE
Upgrades/stac

### DIFF
--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -20,6 +20,8 @@ from sar_pipeline.aws.preparation.burst_utils import (
 )
 
 from sar_pipeline.aws.preparation.config import RTCConfigManager
+from sar_pipeline.aws.metadata.h5 import update_h5_file_metadata
+from sar_pipeline.aws.metadata.geotiffs import update_tif_metadata_in_place
 from sar_pipeline.aws.metadata.stac import BurstH5toStacManager
 from sar_pipeline.aws.metadata.odc import (
     make_static_layer_base_url,
@@ -562,6 +564,15 @@ def make_rtc_opera_stac_and_upload_bursts(
                 f"This error might be caused by repeat runs. Delete duplicate files or change run settings."
             )
         burst_h5_filepath = burst_folder / burst_h5_files[0]
+        burst_tif_files = list(burst_folder.glob("*.tif"))
+        # update GeoTIFFs and h5 metadata to reflect GA processing
+        logging.info(f"Updating .h5 file with GA parameters")
+        update_h5_file_metadata(burst_h5_filepath)
+        logging.info(f"Updating .tif files with GA parameters")
+        for tif_filepath in burst_tif_files:
+            burst_tif_filepath = burst_folder / tif_filepath
+            logging.info(f"Updating : {burst_tif_filepath}")
+            update_tif_metadata_in_place(burst_tif_filepath)
         # make the stac metadata from the .h5 metadata
         logging.info(f"Making stac metadata from .h5 file")
         # initialise the class to convert data from the .h5 to a stac doc

--- a/sar_pipeline/aws/cli.py
+++ b/sar_pipeline/aws/cli.py
@@ -21,7 +21,6 @@ from sar_pipeline.aws.preparation.burst_utils import (
 
 from sar_pipeline.aws.preparation.config import RTCConfigManager
 from sar_pipeline.aws.metadata.h5 import update_h5_file_metadata
-from sar_pipeline.aws.metadata.geotiffs import update_tif_metadata_in_place
 from sar_pipeline.aws.metadata.stac import BurstH5toStacManager
 from sar_pipeline.aws.metadata.odc import (
     make_static_layer_base_url,
@@ -568,11 +567,7 @@ def make_rtc_opera_stac_and_upload_bursts(
         # update GeoTIFFs and h5 metadata to reflect GA processing
         logging.info(f"Updating .h5 file with GA parameters")
         update_h5_file_metadata(burst_h5_filepath)
-        logging.info(f"Updating .tif files with GA parameters")
-        for tif_filepath in burst_tif_files:
-            burst_tif_filepath = burst_folder / tif_filepath
-            logging.info(f"Updating : {burst_tif_filepath}")
-            update_tif_metadata_in_place(burst_tif_filepath)
+        # TODO Update .tif files with GA parameters
         # make the stac metadata from the .h5 metadata
         logging.info(f"Making stac metadata from .h5 file")
         # initialise the class to convert data from the .h5 to a stac doc
@@ -586,7 +581,6 @@ def make_rtc_opera_stac_and_upload_bursts(
         # make the stac item based
         burst_stac_manager.make_stac_item_from_h5()
         # add properties to the stac doc
-        # TODO finalise stac metadata
         burst_stac_manager.add_properties_from_h5()
         # rename the backscatter assets to include calibration
         # i.e. HH.tif -> HH_gamma0.tif

--- a/sar_pipeline/aws/metadata/filetypes.py
+++ b/sar_pipeline/aws/metadata/filetypes.py
@@ -77,3 +77,11 @@ ASSET_FILETYPE_TO_MEDIATYPE = {
     "_interpolated_dem.tif": pystac.media_type.MediaType.COG,
     ".png": pystac.media_type.MediaType.PNG,
 }
+
+UPDATED_METADATA_PARAMETERS = {
+    "CEOS_DOC": "https://ceos.org/ard/files/PFS/SAR/v1.2/CEOS-ARD_PFS_Synthetic_Aperture_Radar_v1.2.pdf",
+    "CEOS_ARD_TYPE": "NRB",
+    "CONTACT_INFO": "earth.observation@ga.gov.au",
+    "INSTITUTION": "Geoscience Australia",
+    "PROJECT": "SAR-ARD",
+}

--- a/sar_pipeline/aws/metadata/geotiffs.py
+++ b/sar_pipeline/aws/metadata/geotiffs.py
@@ -1,4 +1,3 @@
-import rasterio
 from sar_pipeline.aws.metadata.filetypes import UPDATED_METADATA_PARAMETERS
 
 TIF_UPDATED_METADATA_PARAMETERS = {
@@ -12,22 +11,3 @@ TIF_UPDATED_METADATA_PARAMETERS = {
     "INSTITUTION": UPDATED_METADATA_PARAMETERS["INSTITUTION"],
     "PROJECT": UPDATED_METADATA_PARAMETERS["PROJECT"],
 }
-
-import rasterio
-from pathlib import Path
-
-
-def update_tif_metadata_in_place(tif_path: str | Path):
-    """Update or add metadata fields (tags) in-place in a GeoTIFF file.
-
-    Parameters
-    ----------
-    tif_path : str | Path
-        Path to the input .tif file to modify in-place.
-    """
-    tif_path = Path(tif_path)
-
-    with rasterio.open(tif_path, "r+") as dataset:
-        current_tags = dataset.tags()
-        current_tags.update(TIF_UPDATED_METADATA_PARAMETERS)
-        dataset.update_tags(**current_tags)

--- a/sar_pipeline/aws/metadata/geotiffs.py
+++ b/sar_pipeline/aws/metadata/geotiffs.py
@@ -1,0 +1,33 @@
+import rasterio
+from sar_pipeline.aws.metadata.filetypes import UPDATED_METADATA_PARAMETERS
+
+TIF_UPDATED_METADATA_PARAMETERS = {
+    "CEOS_ANALYSIS_READY_DATA_DOCUMENT_IDENTIFIER": UPDATED_METADATA_PARAMETERS[
+        "CEOS_DOC"
+    ],
+    "CEOS_ANALYSIS_READY_DATA_PRODUCT_TYPE": UPDATED_METADATA_PARAMETERS[
+        "CEOS_ARD_TYPE"
+    ],
+    "CONTACT_INFORMATION": UPDATED_METADATA_PARAMETERS["CONTACT_INFO"],
+    "INSTITUTION": UPDATED_METADATA_PARAMETERS["INSTITUTION"],
+    "PROJECT": UPDATED_METADATA_PARAMETERS["PROJECT"],
+}
+
+import rasterio
+from pathlib import Path
+
+
+def update_tif_metadata_in_place(tif_path: str | Path):
+    """Update or add metadata fields (tags) in-place in a GeoTIFF file.
+
+    Parameters
+    ----------
+    tif_path : str | Path
+        Path to the input .tif file to modify in-place.
+    """
+    tif_path = Path(tif_path)
+
+    with rasterio.open(tif_path, "r+") as dataset:
+        current_tags = dataset.tags()
+        current_tags.update(TIF_UPDATED_METADATA_PARAMETERS)
+        dataset.update_tags(**current_tags)

--- a/sar_pipeline/aws/metadata/h5.py
+++ b/sar_pipeline/aws/metadata/h5.py
@@ -1,7 +1,7 @@
 import h5py
 from pathlib import Path
 import numpy as np
-
+from sar_pipeline.aws.metadata.filetypes import UPDATED_METADATA_PARAMETERS
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -229,6 +229,48 @@ class H5Manager:
             else:
                 dest.create_dataset(name, data=item[()])
 
+    def set_value(self, dataset_path: str, value, dtype=None, overwrite=True):
+        """Set or create a dataset at the given path with the specified value.
+
+        Parameters
+        ----------
+        dataset_path : str
+            Path inside the HDF5 file (e.g., 'group1/dataset1').
+        value : any
+            Value to write (scalar or array-like).
+        dtype : np.dtype, optional
+            Data type for the dataset if creating new.
+        overwrite : bool, optional
+            Whether to overwrite an existing dataset. Default is True.
+
+        Raises
+        ------
+        ValueError
+            If the dataset exists and overwrite is False.
+        """
+        # Ensure group exists
+        group_path, _, dataset_name = dataset_path.rpartition("/")
+        group = self._ensure_group(group_path)
+
+        if dataset_name in group:
+            if not overwrite:
+                raise ValueError(
+                    f"Dataset '{dataset_path}' already exists and overwrite is False."
+                )
+            del group[dataset_name]
+
+        # Handle strings explicitly
+        if isinstance(value, str):
+            dtype = h5py.string_dtype(encoding="utf-8")
+            group.create_dataset(dataset_name, data=value, dtype=dtype)
+        else:
+            # Let h5py infer dtype for everything else
+            group.create_dataset(dataset_name, data=value)
+        logger.info(f"Set value at '{dataset_path}'")
+        # Refresh key lists
+        self.keys = self.get_key_list(print_name=False)
+        self.value_keys = self.get_keys_with_values()
+
     def close(self):
         """Close the open file handle."""
         if self.file:
@@ -239,3 +281,30 @@ class H5Manager:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
+
+
+def update_h5_file_metadata(file_path: str):
+    with H5Manager(file_path, mode="r+") as h5:
+        h5.set_value(
+            "identification/ceosAnalysisReadyDataDocumentIdentifier",
+            UPDATED_METADATA_PARAMETERS["CEOS_DOC"],
+            str,
+        )
+        h5.set_value(
+            "identification/ceosAnalysisReadyDataProductType",
+            UPDATED_METADATA_PARAMETERS["CEOS_ARD_TYPE"],
+            str,
+        )
+        h5.set_value(
+            "identification/contactInformation",
+            UPDATED_METADATA_PARAMETERS["CONTACT_INFO"],
+            str,
+        )
+        h5.set_value(
+            "identification/institution",
+            UPDATED_METADATA_PARAMETERS["INSTITUTION"],
+            str,
+        )
+        h5.set_value(
+            "identification/project", UPDATED_METADATA_PARAMETERS["PROJECT"], str
+        )

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -311,6 +311,7 @@ class BurstH5toStacManager:
 
         # proposed sarard stac extension properties
         self.item.properties["sarard:source_id"] = self.h5.search_value("l1SlcGranules")
+        self.item.properties["sarard:source_geometry"] = "slant range"
         self.item.properties["sarard:scene_id"] = self.h5.search_value("l1SlcGranules")[
             0
         ].replace(".SAFE", "")

--- a/sar_pipeline/aws/metadata/stac.py
+++ b/sar_pipeline/aws/metadata/stac.py
@@ -32,6 +32,7 @@ from sar_pipeline.aws.metadata.filetypes import (
     ASSET_FILETYPE_TO_MEDIATYPE,
     ASSET_FILETYPE_TO_ROLES,
     ASSET_FILETYPE_TO_TITLE,
+    UPDATED_METADATA_PARAMETERS,
 )
 
 import logging
@@ -386,7 +387,7 @@ class BurstH5toStacManager:
         self.item.add_link(
             pystac.Link(
                 rel="ceos-ard-specification",
-                target="https://ceos.org/ard/files/PFS/SAR/v1.2/CEOS-ARD_PFS_Synthetic_Aperture_Radar_v1.2.pdf",
+                target=UPDATED_METADATA_PARAMETERS["CEOS_DOC"],
                 media_type=pystac.media_type.MediaType.PDF,
             )
         )
@@ -410,7 +411,7 @@ class BurstH5toStacManager:
             )
         )
 
-        # Add link to the DEM
+        # Add link to the DEM - extract link from description
         self.item.add_link(
             pystac.Link(
                 rel="dem-source",


### PR DESCRIPTION
- Updates for consistent metadata across files
- .H5 tags updated to reference GA processing 
- geotiff updates currently ignored as updating tags completely breaks the COG format that relies on exact byte locations within the file . This will need be be addressed either via edits to the opera/RTC workflow directly, or by regenerating the COG after the tags have been updated. Option 1 is preferred as we can add the change  to our production fork when we bump the isce3 versiob. If option 2, we will need to ensure the settings reflect those used in the original opera/RTC code - https://github.com/opera-adt/RTC/blob/c5cc7403af16bb67fd14f43bf2aec15c6a422297/src/rtc/rtc_s1_single_job.py#L2183 