### PR TITLE
Updates/asf netrc

### DIFF
--- a/sar_pipeline/preparation/downloads/orbits.py
+++ b/sar_pipeline/preparation/downloads/orbits.py
@@ -123,7 +123,7 @@ def download_orbits(
 
         logger.info(f"Starting EOF download from {source}...")
 
-        # The logic in eof.download.main() tries CDSE first by default. set force_asf by source
+        # The logic in eof.download.main() tries CDSE by default. set force_asf if the source is ASF
         try:
             force_asf = source == "ASF"
             try:
@@ -138,7 +138,8 @@ def download_orbits(
                 )
             except:
                 if force_asf:
-                    # remove asf credentials to read from .netrc
+                    # authentication through session credentials may have failed (ASF bug)
+                    # remove explicit credentials to read tem from from .netrc
                     logger.info(
                         "ASF credentials failed. Falling back to .netrc authentication"
                     )

--- a/sar_pipeline/preparation/downloads/scenes.py
+++ b/sar_pipeline/preparation/downloads/scenes.py
@@ -229,6 +229,7 @@ def download_scene_from_asf(
             if use_session:
                 asf_scene_metadata.download(path=download_folder, session=session)
             else:
+                # Default to looking for the .netrc file for authentication if no session is provided.
                 asf_scene_metadata.download(path=download_folder)
         except:
             logger.error(


### PR DESCRIPTION
- Adding in NETRC logic to workaround the temperamental authentication with`asf_search.ASFSession.auth_with_creds()`. See the related GH issue here - https://github.com/asfadmin/Discovery-asf_search/issues/396