### PR TITLE
Update pixi version in GitHub actions

### DIFF
--- a/.github/workflows/run-pytest.yaml
+++ b/.github/workflows/run-pytest.yaml
@@ -10,8 +10,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Run tests
-      uses: prefix-dev/setup-pixi@v0.8.3
+      uses: prefix-dev/setup-pixi@v0.9.2
       with:
-        pixi-version: v0.45.0
+        pixi-version: v0.59.0
         cache: true
     - run: pixi run test-pipeline

--- a/pixi.lock
+++ b/pixi.lock
@@ -277,7 +277,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/b0/c23bd61e1b32c9b96fbca996c87784e196a812da8d621d8d04851f6c8181/tenacity-8.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-14.1.0-pyhd8ed1ab_0.conda
@@ -530,7 +530,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/b0/c23bd61e1b32c9b96fbca996c87784e196a812da8d621d8d04851f6c8181/tenacity-8.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -826,7 +826,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/b0/c23bd61e1b32c9b96fbca996c87784e196a812da8d621d8d04851f6c8181/tenacity-8.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aioboto3-14.1.0-pyhd8ed1ab_0.conda
@@ -1097,7 +1097,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e7/b0/c23bd61e1b32c9b96fbca996c87784e196a812da8d621d8d04851f6c8181/tenacity-8.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl
-      - pypi: .
+      - pypi: ./
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -2029,7 +2029,7 @@ packages:
   timestamp: 1685695754230
 - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.3#41a9331464c5e7eb52759a7ec20e961b45f88d10
   name: dem-handler
-  version: 0.2.4.dev2+g41a9331
+  version: 0.2.3
   requires_dist:
   - boto3>=1.37.1
   - geopandas>=1.0.1
@@ -5971,10 +5971,10 @@ packages:
   - pkg:pypi/s3transfer?source=hash-mapping
   size: 64383
   timestamp: 1740681675666
-- pypi: .
+- pypi: ./
   name: sar-pipeline
-  version: 0.4.1.dev70+ged98aa15b.d20251010
-  sha256: 1902578c726d1637275b275994aa9a3b31e11fc0cc1edf3dc4928df8de51a761
+  version: 0.4.1.dev87+ge431a909c.d20251102
+  sha256: c6e01b15bc976e9a37241584a332109fcc945e02a23f0c118e71f43bbea0df35
   requires_dist:
   - asf-search>=9.0.9
   - boto3>=1.37.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ where = ["."]
 [tool.setuptools.package-data]
 sar_pipeline = ["**/*.yaml", "**/*.yml", "**/*.gpkg", "**/*.json"]
 
-[tool.pixi.project]
+[tool.pixi.workspace]
 channels = ["conda-forge", "avalentino", "s1-etad"]
 platforms = ["linux-64", "osx-arm64"]
 


### PR DESCRIPTION
Pixi's version has advanced a fair bit, so I've updated everything to the latest version.
* Update GitHub action to use latest version of setup-pixi (0.9.2)
* Update GitHub action to use latest version of pixi (0.59.0)