### PR TITLE
dem-handler bugfix

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -320,7 +320,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/23/c2/38547d58f0bdddd42dc57a5f02e23565ee2027b7a1cb8cb9fbb504b9f546/asf_search-10.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/66/92cca3129442856b19d1b94b0551dfa461bd60b302fdae64390bc928dce6/cdsetool-0.2.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/29/db12aa4dda81580be1999824a689bd52aa40061fc12c9ccdc3feab5ea718/dateparser-1.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.4#747cf32b2b774bbbc489c728e806e2db0e789422
+      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.5#19dd2d355ec9822a7d3daae94b947f9bd60467f2
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -634,7 +634,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/23/c2/38547d58f0bdddd42dc57a5f02e23565ee2027b7a1cb8cb9fbb504b9f546/asf_search-10.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/66/92cca3129442856b19d1b94b0551dfa461bd60b302fdae64390bc928dce6/cdsetool-0.2.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/29/db12aa4dda81580be1999824a689bd52aa40061fc12c9ccdc3feab5ea718/dateparser-1.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.4#747cf32b2b774bbbc489c728e806e2db0e789422
+      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.5#19dd2d355ec9822a7d3daae94b947f9bd60467f2
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -988,7 +988,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/67/6db6dff1ebc8965fd7661498aea0da5d7301074b85bba8606a28f47ede4d/black-25.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/66/92cca3129442856b19d1b94b0551dfa461bd60b302fdae64390bc928dce6/cdsetool-0.2.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/29/db12aa4dda81580be1999824a689bd52aa40061fc12c9ccdc3feab5ea718/dateparser-1.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.4#747cf32b2b774bbbc489c728e806e2db0e789422
+      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.5#19dd2d355ec9822a7d3daae94b947f9bd60467f2
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -1321,7 +1321,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/94/cc/f562fe5d0a40cd2a4e6ae3f685e4c36e365b1f7e494af99c26ff7f28117f/black-25.9.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0d/66/92cca3129442856b19d1b94b0551dfa461bd60b302fdae64390bc928dce6/cdsetool-0.2.13-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a4/29/db12aa4dda81580be1999824a689bd52aa40061fc12c9ccdc3feab5ea718/dateparser-1.2.0-py2.py3-none-any.whl
-      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.4#747cf32b2b774bbbc489c728e806e2db0e789422
+      - pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.5#19dd2d355ec9822a7d3daae94b947f9bd60467f2
       - pypi: https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -2832,9 +2832,9 @@ packages:
   - fasttext ; extra == 'fasttext'
   - langdetect ; extra == 'langdetect'
   requires_python: '>=3.7'
-- pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.4#747cf32b2b774bbbc489c728e806e2db0e789422
+- pypi: git+https://github.com/GeoscienceAustralia/dem-handler.git?rev=v0.2.5#19dd2d355ec9822a7d3daae94b947f9bd60467f2
   name: dem-handler
-  version: 0.2.4
+  version: 0.2.5
   requires_dist:
   - boto3>=1.37.1
   - geopandas>=1.0.1
@@ -7693,8 +7693,8 @@ packages:
   timestamp: 1740681675666
 - pypi: ./
   name: sar-pipeline
-  version: 0.4.1.dev231+g2c5ec75eb.d20251201
-  sha256: 8cda1caaf9eafb4816161236d43a0df444a7d6895de4028b4d5aee8113a1f10a
+  version: 0.4.1.dev241+ge830cc90e.d20251204
+  sha256: 38b554daf69192bdf80abd9781f4d7d9e2390e5049aa51ee00f1dda9efe288ec
   requires_dist:
   - asf-search>=9.0.9
   - boto3>=1.37.1
@@ -7706,7 +7706,7 @@ packages:
   - python-dotenv>=1.1.1,<2
   - pystac[validation]==1.13.0
   - antimeridian>=0.4.3,<0.5
-  - dem-handler @ git+https://github.com/GeoscienceAustralia/dem-handler.git@v0.2.4
+  - dem-handler @ git+https://github.com/GeoscienceAustralia/dem-handler.git@v0.2.5
   requires_python: '>=3.8'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.2-py312h4f0b9e3_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "python-dotenv>=1.1.1,<2", 
     "pystac[validation]==1.13.0", 
     "antimeridian>=0.4.3,<0.5", 
-    "dem-handler @ git+https://github.com/GeoscienceAustralia/dem-handler.git@v0.2.4", 
+    "dem-handler @ git+https://github.com/GeoscienceAustralia/dem-handler.git@v0.2.5", 
 ]
 
 [project.urls]


### PR DESCRIPTION
- Fix to ensure the best dem type is selected over the antimeridian.
- Relates to the bugfix in dem-handler - https://github.com/GeoscienceAustralia/dem-handler/releases/tag/v0.2.5
- Prior to this fix, dem-handler was falsely finding intersections for the cop30 DEM over ocean at the antimeridian.