### PR TITLE
Minor docs cleanup

### DIFF
--- a/docs/pipelines/nci_pyrosar_gamma.md
+++ b/docs/pipelines/nci_pyrosar_gamma.md
@@ -34,7 +34,7 @@ The dependant codebases managed by GA used in the pipeline are:
 - [dem-handler](https://github.com/GeoscienceAustralia/dem-handler)
 - [sar-pipeline](https://github.com/GeoscienceAustralia/sar-pipeline/tree/main/sar_pipeline)
 
-The primary output from the pyrosar_gamma pipeline is Normalised Radar Backscatter, including ancillary layers (e.g. local incidence angle). 
+The primary output from the pyrosar_gamma pipeline is Normalised Radar Backscatter, including ancillary layers (e.g. local incidence angle).
 There are no static layers, and outputs are provided at the level of a scene, rather than bursts.
 
 ### 1.1. Requirements
@@ -67,11 +67,11 @@ S1A__EW___A_20250419T221041_pix_ratio_geo_4326.tif
 ### 3.1. Overview
 
 The pipeline has been set up to run via command line interface (CLI) calls on the NCI.
-The CLI is available if you have activated a Conda environment that has sar-pipeline installed. 
+The CLI is available if you have activated a Conda environment that has sar-pipeline installed.
 The CLI functions can be found in the pyrosar_gamma [cli.py](../../sar_pipeline/pipelines/pyrosar_gamma/cli.py).
 
-The login node of the NCI has very limited internet access, so the pipeline is designed to access Sentinel-1 files directly from the NCI. 
-The main approach uses the Copernicus Australasian Datahub (Aus Cop Hub) API to search for a scene's UUID, which is then converted to an NCI path. 
+The login node of the NCI has very limited internet access, so the pipeline is designed to access Sentinel-1 files directly from the NCI.
+The main approach uses the Copernicus Australasian Datahub (Aus Cop Hub) API to search for a scene's UUID, which is then converted to an NCI path.
 If this fails, the pipeline will fall back to searching the older (and no longer updated) filesystem.
 This back-up can be useful in the case of accessing scenes captured prior to mid-2025 if they're not available through the Aus Cop Hub API.
 
@@ -105,7 +105,7 @@ The NCI variables have the following uses:
 Should be of the form `/path/to/conda/install/bin/conda`
 * `NCI_API_SCENE_FILE_LOCATION`: the path to the filesystem containing the Aus Cop Hub scene data holdings for either Australia or Antarctica.
 * `NCI_API_ORBIT_FILE_LOCATION`: the path to the filesystem containing the Aus Cop Hub orbit data holdings for either Australia or Antarctica.
-* `NCI_FILESYSTEM_FILE_LOCATION`: the path to the (now non-updated) filesystem containing the original Aus Cop Hub data holdings, prior to the development and implementation of the API. 
+* `NCI_FILESYSTEM_FILE_LOCATION`: the path to the (now non-updated) filesystem containing the original Aus Cop Hub data holdings, prior to the development and implementation of the API.
 
 For questions about the location of files on the NCI filesystem, contact the Aus Cop Hub team at CopernicusAustralasia@ga.gov.au or via the [website](https://www.copernicus.gov.au/).
 
@@ -116,7 +116,7 @@ At runtime, the [nci-pyrosar-gamma-rtc-submit-workflow ](../../sar_pipeline/pipe
 ```bash
 nci-pyrosar-gamma-rtc-submit-workflow  [OPTIONS] SCENE
 ```
-where `SCENE` is an individual scene ID, path to a scene as a .zip file, or path to a list of scene IDs/paths contained in a single .txt file`. 
+where `SCENE` is an individual scene ID, path to a scene as a .zip file, or path to a list of scene IDs/paths contained in a single .txt file`.
 
 The CLI has the following options:
 
@@ -175,7 +175,7 @@ The corresponding logs and submission script for the above example output can be
 
 Errors to be aware of:
 **Out of memory**
-In the `.ER` file, you will see a message like 
+In the `.ER` file, you will see a message like
 ```text
 Job 154132534 has exceeded memory allocation on node gadi-cpu-clx-2232.gadi.nci.org.au
 ```
@@ -183,15 +183,15 @@ You should resubmit the job with a larger `--mem` value.
 
 ### 3.6 Troubleshooting
 If processing a large number of scenes, the easiest way to check if they've all been processed is to re-submit the same CLI options with the `--dry-run` flag.
-This will create a `missing_scenes_YYYY_MM_DD_HH_MM_SS.txt` in the output folder. 
+This will create a `missing_scenes_YYYY_MM_DD_HH_MM_SS.txt` in the output folder.
 If this file contains any scenes, you can then investigate the logs for those scenes and resubmit once the problem is resolved.
 
 ### 3.7 Setting permissions for external access
 
-Typically, this pipeline is used to process EW scenes for selected users with NCI accounts. 
+Typically, this pipeline is used to process EW scenes for selected users with NCI accounts.
 To ensure they can access their data, you must enable open access on the output folder using `chmod`.
 
-When all scenes have been processed, run 
+When all scenes have been processed, run
 ```bash
 chmod -R +777 /path/to/output/directory
 ```
@@ -253,14 +253,14 @@ For `CONDA_EXE`, this should be set as `/g/data/<project>/<username>/miniforge3/
 
 ### 4.4. Set up symlink for GAMMA
 
-The version of GAMMA currently used by the pipeline (20230712) requires a symlink for `libgdal.so.20`, as this lib file is not available in the Conda environment. 
+The version of GAMMA currently used by the pipeline (20230712) requires a symlink for `libgdal.so.20`, as this lib file is not available in the Conda environment.
 The following steps are used to create the symlink:
 
 1. Create a directory for symlinks
 ```bash
 mkdir /g/data/<project>/<username>/gamma_symlinks
 ```
-2. Identify the location of gdal library files in your Conda environement
+2. Identify the location of gdal library files in your Conda environment
 ```bash
 cd /g/data/<project>/<username>/miniforge3/envs/sar-pipeline/lib
 find . -name "libgdal*"
@@ -272,7 +272,7 @@ cd /g/data/<project>/<username>/gamma_symlinks
 ln -s /g/data/<project>/<username>/miniforge3/envs/sar-pipeline/lib/libgdal.so.36 libgdal.so.20
 ```
 
-You must supply an appropriate `gamma_env_var` path in the configuration file or at run time via the CLI. 
+You must supply an appropriate `gamma_env_var` path in the configuration file or at run time via the CLI.
 To ensure all lib files from the Conda environment are available, as well as the new symlink, use the following:
 ```toml
 gamma_env_var = "/g/data/<project>/<username>/micromamba/envs/sar-pipeline/lib:/g/data/<project>/<username>/gamma_symlinks"

--- a/docs/pipelines/nci_pyrosar_gamma.md
+++ b/docs/pipelines/nci_pyrosar_gamma.md
@@ -239,6 +239,7 @@ $CONDA_PREFIX/bin/conda init bash
 Once Conda is installed, make sure it's initialised (you should see `(base)` at the start of your terminal prompt), then navigate to the `sar-pipeline` repository.
 
 Run the following commands to install the required Conda environments:
+
 `sar-pipeline`
 ```bash
 conda env create -f environment.yaml && conda clean -afy

--- a/docs/pipelines/nci_pyrosar_gamma.md
+++ b/docs/pipelines/nci_pyrosar_gamma.md
@@ -34,7 +34,7 @@ The dependant codebases managed by GA used in the pipeline are:
 - [dem-handler](https://github.com/GeoscienceAustralia/dem-handler)
 - [sar-pipeline](https://github.com/GeoscienceAustralia/sar-pipeline/tree/main/sar_pipeline)
 
-The primary output from the pyrosar_gamma pipeline is Normalised Radar Backscatter, including ancillary layers (e.g. local incidence angle).
+The primary output from the `pyrosar_gamma` pipeline is Normalised Radar Backscatter, including ancillary layers (e.g. local incidence angle).
 There are no static layers, and outputs are provided at the level of a scene, rather than bursts.
 
 ### 1.1. Requirements
@@ -68,7 +68,7 @@ S1A__EW___A_20250419T221041_pix_ratio_geo_4326.tif
 
 The pipeline has been set up to run via command line interface (CLI) calls on the NCI.
 The CLI is available if you have activated a Conda environment that has sar-pipeline installed.
-The CLI functions can be found in the pyrosar_gamma [cli.py](../../sar_pipeline/pipelines/pyrosar_gamma/cli.py).
+The CLI functions can be found in the `pyrosar_gamma` [cli.py](../../sar_pipeline/pipelines/pyrosar_gamma/cli.py).
 
 The login node of the NCI has very limited internet access, so the pipeline is designed to access Sentinel-1 files directly from the NCI.
 The main approach uses the Copernicus Australasian Datahub (Aus Cop Hub) API to search for a scene's UUID, which is then converted to an NCI path.
@@ -81,7 +81,7 @@ At runtime, the pipeline expects the following environment variables to be set.
 These can be passed in using an environment file (`.env`).
 
 Credentials for the Aus Cop Hub were provided internally.
-The Aus Cop Hub can be contacted at CopernicusAustralasia@ga.gov.au or via the [website](https://www.copernicus.gov.au/).
+The Aus Cop Hub can be contacted at `CopernicusAustralasia@ga.gov.au` or via the [website](https://www.copernicus.gov.au/).
 
 [.env.example](../../.env.example)
 
@@ -107,7 +107,7 @@ Should be of the form `/path/to/conda/install/bin/conda`
 * `NCI_API_ORBIT_FILE_LOCATION`: the path to the filesystem containing the Aus Cop Hub orbit data holdings for either Australia or Antarctica.
 * `NCI_FILESYSTEM_FILE_LOCATION`: the path to the (now non-updated) filesystem containing the original Aus Cop Hub data holdings, prior to the development and implementation of the API.
 
-For questions about the location of files on the NCI filesystem, contact the Aus Cop Hub team at CopernicusAustralasia@ga.gov.au or via the [website](https://www.copernicus.gov.au/).
+For questions about the location of files on the NCI filesystem, contact the Aus Cop Hub team at `CopernicusAustralasia@ga.gov.au` or via the [website](https://www.copernicus.gov.au/).
 
 ### 3.3. Pipeline arguments and configuration
 
@@ -116,7 +116,8 @@ At runtime, the [nci-pyrosar-gamma-rtc-submit-workflow ](../../sar_pipeline/pipe
 ```bash
 nci-pyrosar-gamma-rtc-submit-workflow  [OPTIONS] SCENE
 ```
-where `SCENE` is an individual scene ID, path to a scene as a .zip file, or path to a list of scene IDs/paths contained in a single .txt file`.
+
+where `SCENE` is an individual scene ID, path to a scene as a .zip file, or path to a list of scene IDs/paths contained in a single `.txt` file.
 
 The CLI has the following options:
 
@@ -141,7 +142,7 @@ The CLI has the following options:
 --help
 ```
 
-* `config` -> A .toml file that specifies values for all the above options, which will be used by default if no other value is provided.
+* `config` -> A `.toml` file that specifies values for all the above options, which will be used by default if no other value is provided.
 * `spacing` -> The target resolution for the output product, typically 40 for EW.
 * `scaling` -> The value scaling of the backscatter values; one of `linear`, `db` or `both`.
 * `target-crs` -> The EPSG number for the target coordinate reference system. Only 4326 and 3031 are supported.
@@ -150,14 +151,14 @@ The CLI has the following options:
 * `etad-dir` -> Path to where ETAD correction files are stored. If provided, the ETAD correction will be applied.
 * `output-dir` -> Path to where outputs will be stored.
 * `gamma-lib-dir` -> Path to GAMMA software binaries.
-* `gamma-env-var` -> Environment variable to point to symlinked .so objects to ensure GAMMA runs.
-* `ncpu` -> Number of CPU to request.
+* `gamma-env-var` -> Environment variable to point to symlinked `.so` objects to ensure GAMMA runs.
+* `ncpu` -> Number of CPUs to request.
 * `mem` -> Amount of memory to request in GB.
 * `queue` -> NCI queue to submit to.
 * `project` -> NCI project to submit to.
 * `walltime` -> Amount of walltime to request for the job.
 * `dry-run` -> Flag for dry-run. Produces the submission script without launching it.
-* `dotenv-location` -> Location of the environment file (.env). Assumed to be the project root directory if not provided.
+* `dotenv-location` -> Location of the environment file (`.env`). Assumed to be the project root directory if not provided.
 * `help` -> Show the CLI help message.
 
 ### 3.4 Example product outputs
@@ -235,7 +236,7 @@ $CONDA_PREFIX/bin/conda init bash
 ```
 
 ### 4.2. Add required Conda environments
-Once Conda is installed, make sure it's initialised (you should see `(base)` at the start of your terminal prompt), then, navigate to the `sar-pipeline repository`.
+Once Conda is installed, make sure it's initialised (you should see `(base)` at the start of your terminal prompt), then navigate to the `sar-pipeline` repository.
 
 Run the following commands to install the required Conda environments:
 `sar-pipeline`
@@ -280,7 +281,7 @@ gamma_env_var = "/g/data/<project>/<username>/micromamba/envs/sar-pipeline/lib:/
 
 ### 4.5 Initialise pyroSAR
 
-The pyroSAR library is a python wrapper for various GAMMA command line utilities.
+The `pyroSAR` library is a python wrapper for various GAMMA command line utilities.
 As such, it needs to read the GAMMA commands and create the appropriate Python wrapper functions before first use.
 
 You can check whether it exists by seeing if you have a folder at `~/.pyrosar/gammaparse`.
@@ -294,7 +295,7 @@ conda activate sar-pipeline
 ```bash
 python
 ```
-3. Specify the required paths, set these as environment variables, then run the GAMMA `autoparse` function from pyroSAR:
+3. Specify the required paths, set these as environment variables, then run the GAMMA `autoparse` function from `pyroSAR`:
 ```python
 >>> gamma_lib_dir = "/g/data/dg9/GAMMA/GAMMA_SOFTWARE-20230712"
 >>> gamma_env_var = "/g/data/<project>/<username>/micromamba/envs/sar-pipeline/lib:/g/data/<project>/<username>/gamma_symlinks"
@@ -350,9 +351,10 @@ nci-pyrosar-gamma-rtc-submit-workflow  -c /g/data/<project>/<username>/sar-pipel
 
 ## 6. Development environment setup
 
-Install pixi into your home directory on NCI
+Install `pixi` into your home directory on NCI
 ```bash
 curl -fsSL https://pixi.sh/install.sh | bash
 ```
 
-From there, you should be able to run pixi commands on NCI.
+From there, you should be able to run `pixi` commands on NCI systems.
+

--- a/docs/pipelines/nci_pyrosar_gamma.md
+++ b/docs/pipelines/nci_pyrosar_gamma.md
@@ -276,7 +276,7 @@ ln -s /g/data/<project>/<username>/miniforge3/envs/sar-pipeline/lib/libgdal.so.3
 You must supply an appropriate `gamma_env_var` path in the configuration file or at run time via the CLI.
 To ensure all lib files from the Conda environment are available, as well as the new symlink, use the following:
 ```toml
-gamma_env_var = "/g/data/<project>/<username>/micromamba/envs/sar-pipeline/lib:/g/data/<project>/<username>/gamma_symlinks"
+gamma_env_var = "/g/data/<project>/<username>/miniforge3/envs/sar-pipeline/lib:/g/data/<project>/<username>/gamma_symlinks"
 ```
 
 ### 4.5 Initialise pyroSAR
@@ -298,7 +298,7 @@ python
 3. Specify the required paths, set these as environment variables, then run the GAMMA `autoparse` function from `pyroSAR`:
 ```python
 >>> gamma_lib_dir = "/g/data/dg9/GAMMA/GAMMA_SOFTWARE-20230712"
->>> gamma_env_var = "/g/data/<project>/<username>/micromamba/envs/sar-pipeline/lib:/g/data/<project>/<username>/gamma_symlinks"
+>>> gamma_env_var = "/g/data/<project>/<username>/miniforge3/envs/sar-pipeline/lib:/g/data/<project>/<username>/gamma_symlinks"
 >>> from sar_pipeline.utils.gamma import set_gamma_env_variables
 >>> set_gamma_env_variables(gamma_lib_dir, gamma_env_var)
 >>> from pyroSAR.gamma.parser import autoparse

--- a/docs/pipelines/pyrosar_gamma.md
+++ b/docs/pipelines/pyrosar_gamma.md
@@ -24,12 +24,12 @@ The dependant codebases managed by GA used in the pipeline are:
 - [dem-handler](https://github.com/GeoscienceAustralia/dem-handler)
 - [sar-pipeline](https://github.com/GeoscienceAustralia/sar-pipeline/tree/main/sar_pipeline)
 
-The primary output from the pyrosar_gamma pipeline is Normalised Radar Backscatter, including ancillary layers (e.g. local incidence angle). 
+The primary output from the pyrosar_gamma pipeline is Normalised Radar Backscatter, including ancillary layers (e.g. local incidence angle).
 There are no static layers, and outputs are provided at the level of a scene, rather than bursts.
 
 ### 1.1. Requirements
 
-You will need an AWS EC2 instance to run the code in. (TODO add specs!) 
+You will need an AWS EC2 instance to run the code in. (TODO add specs!)
 
 ## 2. Example products
 
@@ -53,7 +53,7 @@ S1A__EW___A_20250419T221041_pix_ratio_geo.tif
 ### 3.1. Overview
 
 The pipeline has been set up to run via command line interface (CLI) calls on the AWS EC2 instance.
-**NOTE**: The CLI is available if you have activated a Pixi environment that has sar-pipeline installed. 
+**NOTE**: The CLI is available if you have activated a Pixi environment that has sar-pipeline installed.
 The CLI functions can be found in the pyrosar_gamma [cli.py](../../sar_pipeline/pipelines/pyrosar_gamma/aws/cli.py).
 
 ### 3.2. Environment variables
@@ -88,7 +88,7 @@ After activating the required Pixi environment and at runtime, the [pyrosar-gamm
 ```bash
 ../../sar_pipeline/pipelines/pyrosar_gamma/aws/cli.py  --scene SCENE [OPTIONS]
 ```
-where `SCENE` is an individual scene ID. 
+where `SCENE` is an individual scene ID.
 
 This command will by default create and use `sar-processing` directory inside the project root. The intermediate files will be downloaded to `sar-processing/downloads` and the outputs will go into `sar-processing/r1_rtc` folder. These paths could be controlled via `--download-folder` and `--out-folder` arguments.
 
@@ -106,7 +106,7 @@ The CLI has the following options:
 --geocode-spacing INTEGER
 --geocode-scaling [linear|db|both]
 --etad DIRECTORY
---make-folders 
+--make-folders
 --dotenv-location TEXT
 --target-crs [4326|3031]
 --help
@@ -118,7 +118,7 @@ The CLI has the following options:
 * `out-folder` -> Path to the folder where final products will be written.
 * `scene-data-source` -> Where to download the scene from. Can be passed as a string or list of preferences separated by a space. If the scene cannot be found at the first preference, the next will be used. One or a space separated list of `AUS_COP_HUB`, `CDSE`, `ASF`.
 * `orbit-data-source` -> Where to download the orbit files from. Can be passed as a string or list of preferences separated by a space. If the orbits files cannot be found at the first preference, the next will be used. One or a space separated list of `AUS_COP_HUB`, `CDSE`, `ASF`.
-* `gamma-library` -> Path to the gamma library for processing. 
+* `gamma-library` -> Path to the gamma library for processing.
 * `gamma-env` -> Name of the gamma environment for processing. This should be set up with the gamma library specified by --gamma-library. By default set to "<Project_root>/.pixi/envs/default/lib:$HOME/gamma_symlinks" .
 * `geocode-spacing` -> The geocoding grid spacing in meters. Default is 20m..
 * `geocode-scaling` -> The scaling convention for the geocoded output. Default is 'both', which rescales the values using linear and decibel scaling; one of `linear`, `db` or `both`.
@@ -146,8 +146,8 @@ Copy the GAMMA software's files to `/usr/local/GAMMA_SOFTWARE-20230712` if you h
 
 ### 4.3. Running sar-pipeline in Docker image
 
-The workflow could be run using a docker image. The docker file can be found at [Docker/pyrosar_gamma/Dockerfile](../../Docker/pyrosar_gamma/Dockerfile). 
-You can build the docker image via the command: 
+The workflow could be run using a docker image. The docker file can be found at [Docker/pyrosar_gamma/Dockerfile](../../Docker/pyrosar_gamma/Dockerfile).
+You can build the docker image via the command:
 
 ```bash
 docker build -t sar-pipeline -f Docker/pyrosar_gamma/Dockerfile .
@@ -159,21 +159,21 @@ pyrosar-gamma-rtc-run-docker-container --scene SCENE
 ```
 
 This will assume that you have a `.env` file present in the root folder of your project and GAMMA software is locate locally at `/usr/local/GAMMA_SOFTWARE-20230712`
-Again running the image will download and generate files in the default folders as explained in [3.3](#33-pipeline-arguments-and-configuration). 
+Again running the image will download and generate files in the default folders as explained in [3.3](#33-pipeline-arguments-and-configuration).
 
-Alternatively you can run the image via `docker run` command and pass the desired arguments to the entry point. 
+Alternatively you can run the image via `docker run` command and pass the desired arguments to the entry point.
 
-### 4.4. Running sar-pipeline locally 
+### 4.4. Running sar-pipeline locally
 
 1. Install the dependencies required to run the software
 
 ```bash
-sudo apt update 
+sudo apt update
 sudo apt-get install libsqlite3-dev libzstd-dev libwebp-dev libjson-c-dev libgtk-3-0
 ```
 
 2. Create a symlink to the required library by GAMMA software.
-The version of GAMMA currently used by the pipeline (20230712) requires a symlink for `libgdal.so.20`, as this lib file is not available in the Pixi environment. 
+The version of GAMMA currently used by the pipeline (20230712) requires a symlink for `libgdal.so.20`, as this lib file is not available in the Pixi environment.
 The following steps are used to create the symlink:
 
   * Create a directory for symlinks
@@ -186,7 +186,7 @@ cd $PROJECT_ROOT/.pixi/envs/default/lib
 find . -name "libgdal*"
 ```
 Where `$PROJECT_ROOT` is the absolute path to the root directory of your project.
-  * Confirm that `./libgdal.so.38` appears in the list. version number `38` could change depending on the version of GDAL installed, therefore you might see a different number. 
+  * Confirm that `./libgdal.so.38` appears in the list. version number `38` could change depending on the version of GDAL installed, therefore you might see a different number.
   * Create the symlink
 ```bash
 cd ~/gamma_symlinks
@@ -204,19 +204,19 @@ export LD_LIBRARY_PATH="$PROJECT_ROOT/.pixi/envs/default/lib:$HOME/gamma_symlink
 
 4. The pyroSAR library is a python wrapper for various GAMMA command line utilities.
 As such, it needs to read the GAMMA commands and create the appropriate Python wrapper functions before first use.
-You can check whether it exists by seeing if you have a folder at `~/.pyrosar/gammaparse`. 
+You can check whether it exists by seeing if you have a folder at `~/.pyrosar/gammaparse`.
 If the files do not exist, they will be automatically generated when you run the pipeline. If they exist, the automatic generation will be skipped.
 If the files are not generated at runtime, the most likely underlying reasons fo the issue are:
   * The prerequisites are not installed properly (step 2).
   * The symlink is not created correctly.
-  * The environment variables are not set correctly 
+  * The environment variables are not set correctly
 
 
 **Note** It is not required but you can also pre-generate the pyroSAR python bindings by running the script below:
 
   1. Activate the sar-pipeline conda environment
 ```bash
-pixi shell 
+pixi shell
 ```
   2. Set the `PROJECT_ROOT` environment variable via an `export` command.
   3. Run a new Python REPL
@@ -243,7 +243,7 @@ msp.py
 __pycache__
 ```
 
-### 4.5. Standalone GAMMA software 
+### 4.5. Standalone GAMMA software
 **Note**: <I>**This is not required for running `sar-pipeline`.**</I> This is just to install the software and use it via its own commands and python bindings if required. `sar-pipeline` uses different libraries for the GAMMA software's python bindings which is explained in previous sections.
 
 If you wanted to run GAMMA software as an standalone tool and not via the `sar-pipeline` package, you should follow the GAMMA software's installation documentation and as part of it install GDAL and PROJ. In some cases installing GDAL and PROJ from package manager will not install the right version and there will be missing libraries. If you are getting GDAL or PROJ related errors, you will need to build the packages from source then.
@@ -253,4 +253,4 @@ In section 4 of the `INSTALL_linux.html` file from GAMMA software's documentatio
 Add `#include <limits>` to the top of `gdal-2.4.2/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp` file and then build GDAL.
 
 If you have followed the installation guide correctly (specially when setting the environment variables) GAMMA commands such as `disras` should work.
- 
+


### PR DESCRIPTION
This is a quick PR to fix some minor things in some docs:
* Trailing whitespace
* Typos
* Layout formatting
* Some `code` style formatting

This brings across some changes on an older branch (predating splitting the docs by AWS/NCI platform).